### PR TITLE
修复关闭长按下展开卡片还能长按的问题

### DIFF
--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MyAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MyAdapter.kt
@@ -88,7 +88,15 @@ class MyAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         notifyItemChanged(adapterPosition)
                     }
                     tv_desc.setOnLongClickListener {
+                        if (SpUtil.getBoolean(it.context, "longPressCard", true)) {
                         showDialog(it.context, list[adapterPosition].jsonString.toPrettyFormat())
+                        } else {
+                            Toast.makeText(
+                                it.context,
+                                "未开启长按查看详情功能\n请前往设置开启",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
                         true
                     }
                 }


### PR DESCRIPTION
- 修复设置里关闭长按弹出详情后展开卡片还能长按弹出详情的问题