### PR TITLE
使用 Material 3 组件库改写 Spinner

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.databinding:databinding-common:8.3.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
@@ -24,4 +24,8 @@ object SpUtil {
 
     fun putBoolean(context: Context, key: String, value: Boolean) =
         getSp(context).edit().putBoolean(key, value).apply()
+
+    fun deleteSp(context: Context, key: String) =
+        getSp(context).edit().remove(key).apply()
+
 }

--- a/app/src/main/res/layout/dialog_guess.xml
+++ b/app/src/main/res/layout/dialog_guess.xml
@@ -19,7 +19,10 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:hint="主版本号（x.y.z）">
+            android:layout_marginEnd="8dp"
+            app:helperTextEnabled="true"
+            app:helperText="格式为 x.y.z"
+            android:hint="主版本号">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"
@@ -29,11 +32,31 @@
         </com.google.android.material.textfield.TextInputLayout>
 
 
-        <Spinner
+        <!--<Spinner
             android:id="@+id/spinner_version"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:entries="@array/version" />
+            android:entries="@array/version" />-->
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/spinner_layout"
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            app:helperTextEnabled="true"
+            app:helperText="指定猜版版本"
+            android:hint="版本">
+
+            <AutoCompleteTextView
+                android:id="@+id/spinner_version"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none"
+                app:simpleItems="@array/version" />
+
+        </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>
 
     <com.google.android.material.textfield.TextInputLayout
@@ -42,7 +65,9 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="10dp"
-        android:hint="起始猜测小版本号，每次+5">
+        app:helperTextEnabled="true"
+        app:helperText="起始猜测小版本号，每次 +5"
+        android:hint="起始小版本号">
 
         <com.google.android.material.textfield.TextInputEditText
             android:layout_width="match_parent"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="version">
-        <item>测试版</item>
         <item>正式版</item>
+        <item>测试版</item>
         <item>空格版</item>
     </string-array>
 </resources>


### PR DESCRIPTION
- 使用 Material 3 组件库 Menus+TextField 改写 Spinner
- 修复在“正式版”状态下打开猜版对话框出现界面闪现的 Bug
- **已知 Bug：点击猜版对话框背后区域会唤起使用 Material 3 组件库 Menus+TextField 改写的 Spinner（AutoCompleteTextView）**（https://github.com/material-components/material-components-android/issues/4081 ）