### PR TITLE
更新 MDC 至 1.12.0-alpha03，调整设置间距，将进度条更新为新样式， 新增 Bottom App Bar 在上滑列表时可自动隐藏

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("com.google.android.material:material:1.11.0")
+    implementation("com.google.android.material:material:1.12.0-alpha03")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.databinding:databinding-common:8.3.0")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -66,7 +66,7 @@ class MainActivity : AppCompatActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
     }
 
-    fun Context.dpToPx(dp: Int): Int {
+    private fun Context.dpToPx(dp: Int): Int {
         return (dp * resources.displayMetrics.density).toInt()
     }
 
@@ -75,7 +75,6 @@ class MainActivity : AppCompatActivity() {
             outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State
         ) {
             with(outRect) {
-
                 // 对于每一项都添加底部间距
                 bottom = space
                 // 如果不是第一行，则添加顶部间距
@@ -119,9 +118,8 @@ class MainActivity : AppCompatActivity() {
 
 
     private fun initButtons() {
-        //删除 version Shared Preferences
+        // 删除 version Shared Preferences
         SpUtil.deleteSp(this, "version")
-
 
         //这里的“getInt: userAgreement”的值代表着用户协议修订版本，后续更新协议版本后也需要在下面一行把“judgeUARead”+1，以此类推
         val judgeUARead = 1
@@ -129,15 +127,14 @@ class MainActivity : AppCompatActivity() {
             UADialog(false)
         }
 
+        // var currentQQVersion = ""
 
-        //var currentQQVersion = ""
-
-        //进度条动画
-        //https://github.com/material-components/material-components-android/blob/master/docs/components/ProgressIndicator.md
+        // 进度条动画
+        // https://github.com/material-components/material-components-android/blob/master/docs/components/ProgressIndicator.md
 
         binding.progressLine.apply {
-            showAnimationBehavior = LinearProgressIndicator.SHOW_INWARD
-            hideAnimationBehavior = LinearProgressIndicator.HIDE_OUTWARD
+            showAnimationBehavior = LinearProgressIndicator.SHOW_NONE
+            hideAnimationBehavior = LinearProgressIndicator.HIDE_ESCAPE
             //setVisibilityAfterHide(View.GONE)
         }
 
@@ -316,7 +313,7 @@ class MainActivity : AppCompatActivity() {
             dialogGuessBinding.spinnerVersion.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(p0: Editable?) {
                     val judgeVerSelect = dialogGuessBinding.spinnerVersion.text.toString()
-                    SpUtil.putString(this@MainActivity, "versionSelect", judgeVerSelect.toString())
+                    SpUtil.putString(this@MainActivity, "versionSelect", judgeVerSelect)
                     if (judgeVerSelect == "测试版" || judgeVerSelect == "空格版") {
                         dialogGuessBinding.etVersionSmall.isEnabled = true
                         dialogGuessBinding.guessDialogWarning.visibility = View.VISIBLE
@@ -324,12 +321,9 @@ class MainActivity : AppCompatActivity() {
                         dialogGuessBinding.etVersionSmall.isEnabled = false
                         dialogGuessBinding.guessDialogWarning.visibility = View.GONE
                     }
-
                 }
-
                 override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
                 }
-
                 override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
                 }
             })

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -45,13 +45,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <com.google.android.material.progressindicator.LinearProgressIndicator
-        android:id="@+id/progress_line"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:indeterminate="true"
-        app:layout_anchor="@id/topAppBar"
-        app:layout_anchorGravity="bottom|end" />
+
 
     <com.google.android.material.bottomappbar.BottomAppBar
         android:id="@+id/bottomAppBar"
@@ -60,6 +54,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:fitsSystemWindows="true"
+        app:hideOnScroll="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:menu="@menu/bottom_app_bar" />
 
@@ -69,5 +64,16 @@
         android:layout_height="wrap_content"
         app:layout_anchor="@id/bottomAppBar"
         app:srcCompat="@drawable/search_line" />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/progress_line"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:elevation="10dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        app:layout_anchor="@id/topAppBar"
+        app:layout_anchorGravity="bottom" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/dialog_loading.xml
+++ b/app/src/main/res/layout/dialog_loading.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal"

--- a/app/src/main/res/layout/dialog_setting.xml
+++ b/app/src/main/res/layout/dialog_setting.xml
@@ -4,33 +4,33 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    android:paddingBottom="20dp"
-    android:paddingTop="6dp"
     android:paddingStart="20dp"
-    android:paddingEnd="20dp">
+    android:paddingTop="6dp"
+    android:paddingEnd="20dp"
+    android:paddingBottom="20dp">
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/switch_display_first"
         android:layout_width="match_parent"
-        android:paddingBottom="16dp"
-        android:paddingTop="16dp"
         android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:paddingBottom="8dp"
         android:text="版本列表首项默认展开" />
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/long_press_card"
         android:layout_width="match_parent"
-        android:paddingBottom="16dp"
-        android:paddingTop="16dp"
         android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         android:text="长按版本列表文字弹出详细信息" />
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/guess_not_5"
         android:layout_width="match_parent"
-        android:paddingBottom="16dp"
-        android:paddingTop="16dp"
         android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:paddingBottom="16dp"
         android:text="解除小版本号及猜版遵循 5 的倍数限制" />
 
     <Button

--- a/app/src/main/res/menu/bottom_app_bar.xml
+++ b/app/src/main/res/menu/bottom_app_bar.xml
@@ -19,7 +19,7 @@
         android:id="@+id/btn_get"
         android:icon="@drawable/refresh_line"
         android:title="刷新"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom"/>
 
 
 </menu>


### PR DESCRIPTION
- 更新 [Material Components for Android（MDC-Android）](https://github.com/material-components/material-components-android/tree/master)至 [1.12.0-alpha03](https://github.com/material-components/material-components-android/releases/tag/1.12.0-alpha03)
- 调整设置子项间距
- 将进度条更新为 MDC 2023 年 12 月新样式，线性进度条退出动画更改为 `escape`
- 新增 `Bottom App Bar` 在上滑列表时可自动隐藏，下滑再显示