### PR TITLE
修复猜版协程更新 UI 不在主线程的问题、优化更新文本后才显示猜版进行对话框、更改用户协议对话框下方按钮颜色、猜版对话框点击开始后自动清除输入框焦点、新增版本列表展开态的包大小指示器、“体验说明”开头添加短横线前缀、当“体验说明”标题为空时不展示

### DIFF
--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -61,7 +61,6 @@ import com.xiaoniu.qqversionlist.util.SpUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -559,7 +558,7 @@ class MainActivity : AppCompatActivity() {
                                         "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64_HB.apk"
                                 }
                             }
-                            GlobalScope.launch(Dispatchers.Main) {
+                            runOnUiThread {
                                 updateProgressDialogMessage("正在猜测下载地址：$link")
                             }
                             val okHttpClient = OkHttpClient()

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -59,7 +59,6 @@ import com.xiaoniu.qqversionlist.util.InfoUtil.showToast
 import com.xiaoniu.qqversionlist.util.LogUtil.log
 import com.xiaoniu.qqversionlist.util.SpUtil
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -506,7 +505,6 @@ class MainActivity : AppCompatActivity() {
 
 
     //https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_8.9.75.XXXXX_64.apk
-    @OptIn(DelicateCoroutinesApi::class)
     private fun guessUrl(versionBig: String, versionSmall: Int, mode: String) {
         // 绑定 AlertDialog 加载对话框布局
         val dialogView = layoutInflater.inflate(R.layout.dialog_loading, null)

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -35,6 +35,7 @@ import com.xiaoniu.qqversionlist.databinding.ItemVersionBinding
 import com.xiaoniu.qqversionlist.databinding.ItemVersionDetailBinding
 import com.xiaoniu.qqversionlist.util.SpUtil
 import com.xiaoniu.qqversionlist.util.StringUtil.toPrettyFormat
+import okhttp3.internal.format
 
 class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -68,9 +69,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             0 -> {
                 ViewHolder(
                     ItemVersionBinding.inflate(
-                        LayoutInflater.from(parent.context),
-                        parent,
-                        false
+                        LayoutInflater.from(parent.context), parent, false
                     )
                 ).apply {
                     binding.ibExpand.setOnClickListener {
@@ -97,9 +96,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             else -> {
                 ViewHolderDetail(
                     ItemVersionDetailBinding.inflate(
-                        LayoutInflater.from(parent.context),
-                        parent,
-                        false
+                        LayoutInflater.from(parent.context), parent, false
                     )
                 ).apply {
                     binding.ibCollapse.setOnClickListener {
@@ -109,8 +106,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                     binding.tvDesc.setOnLongClickListener {
                         if (SpUtil.getBoolean(it.context, "longPressCard", true)) {
                             showDialog(
-                                it.context,
-                                list[adapterPosition].jsonString.toPrettyFormat()
+                                it.context, list[adapterPosition].jsonString.toPrettyFormat()
                             )
                         } else {
                             Toast.makeText(
@@ -134,7 +130,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             holder.binding.tvContent.text = result
             if (!SpUtil.getBoolean(holder.itemView.context, "progressSize", false)) {
                 holder.binding.listProgressLine.visibility = View.GONE
-            } else{
+            } else {
                 holder.binding.listProgressLine.visibility = View.VISIBLE
                 holder.binding.listProgressLine.max =
                     ((list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 10).toInt()
@@ -153,7 +149,29 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 tvVersion.text = "版本：${bean.versionNumber}"
                 tvSize.text = "大小：${bean.size} MB"
                 tvTitle.text = bean.featureTitle
-                tvDesc.text = bean.summary.joinToString(separator = "\n")
+                tvDesc.text = bean.summary.joinToString(separator = "\n- ", prefix = "- ")
+                tvPerSize.text =
+                    "占比历史最大包（${(list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f)} MB）：${"%.2f".format(bean.size.toFloat() / (list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 100)}%"
+
+                if (!SpUtil.getBoolean(holder.itemView.context, "progressSize", false)) {
+                    holder.binding.listDetailProgressLine.visibility = View.GONE
+                    holder.binding.tvPerSize.visibility = View.GONE
+                } else {
+                    holder.binding.listDetailProgressLine.visibility = View.VISIBLE
+                    holder.binding.tvPerSize.visibility = View.VISIBLE
+                    holder.binding.listDetailProgressLine.max =
+                        ((list.maxByOrNull { it.size.toFloat() }?.size?.toFloat()
+                            ?: 0f) * 10).toInt()
+                    holder.binding.listDetailProgressLine.progress =
+                        (bean.size.toFloat() * 10).toInt()
+                }
+
+                if (tvTitle.text==""){
+                    holder.binding.tvTitle.visibility = View.GONE
+                } else {
+                    holder.binding.tvTitle.visibility = View.VISIBLE
+                }
+
             }
         }
     }

--- a/app/src/main/res/layout/dialog_setting.xml
+++ b/app/src/main/res/layout/dialog_setting.xml
@@ -47,7 +47,7 @@
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
-        android:text="版本列表折叠态展示当前包大小占比最大包指示条" />
+        android:text="版本列表展示当前包大小占比最大包指示条" />
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/guess_not_5"

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -58,18 +58,38 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView
+            android:id="@+id/tv_per_size"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            tools:text="占比历史最大包（）："
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/item_old" />
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/list_detail_progress_line"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="10dp"
+            app:layout_anchorGravity="bottom"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_per_size"
+            android:paddingTop="3dp"
+            android:paddingBottom="6dp"/>
+
+        <TextView
             android:id="@+id/tv_title"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             tools:text="体验说明："
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/item_old" />
+            app:layout_constraintTop_toBottomOf="@id/list_detail_progress_line" />
 
         <TextView
             android:id="@+id/tv_desc"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:paddingBottom="4dp"
+            android:paddingBottom="6dp"
             tools:text="新年新“状态”"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title" />

--- a/app/src/main/res/layout/user_agreement.xml
+++ b/app/src/main/res/layout/user_agreement.xml
@@ -256,8 +256,10 @@
             style="@style/Widget.Material3.Button.TonalButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="不同意并退出" />
-
+            android:text="不同意并退出"
+            android:textColor="?attr/colorOnErrorContainer"
+            app:backgroundTint="?attr/colorErrorContainer"
+            app:iconTint="?attr/colorOnErrorContainer" />
 
 
     </LinearLayout>


### PR DESCRIPTION
## 修复

- 修复：猜版协程更新 UI 不在主线程的问题

## 新增

- 新增：版本列表展开态的包大小指示器

## 优化

- 优化：更新文本后才显示猜版进行对话框
- 优化：更改用户协议对话框下方按钮颜色
- 优化：猜版对话框点击开始后自动清除输入框焦点
- 优化：“体验说明”开头添加短横线前缀
- 优化：当“体验说明”标题为空时不展示