### PR TITLE
去除可能存在的系统栏遮罩、去除点击猜版Spinner就隐藏软键盘的逻辑、关于页作者添加“其他贡献者”、修复版本列表部分文字无法触发长按动作的问题、优化猜版对话框点击开始后关闭软键盘

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ QQ 版本列表实用工具 for Android 是一个提供 QQ 版本列表的查看
 ## 贡献成员
 
 <a href="https://github.com/klxiaoniu/QQVersionList/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=klxiaoniu/QQVersionList" />
+  <img src="https://contrib.rocks/image?repo=klxiaoniu/QQVersionList"  alt="贡献成员"/>
 </a>
 
 ## 开源相关

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -33,6 +33,7 @@ import android.text.SpannableString
 import android.text.TextWatcher
 import android.text.style.URLSpan
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -124,8 +125,12 @@ class MainActivity : AppCompatActivity() {
         val userAgreementBinding = UserAgreementBinding.inflate(layoutInflater)
 
         val dialogUA =
-            MaterialAlertDialogBuilder(this).setTitle("用户协议").setIcon(R.drawable.file_user_line)
-                .setView(userAgreementBinding.root).setCancelable(false).create()
+            MaterialAlertDialogBuilder(this)
+                .setTitle("用户协议")
+                .setIcon(R.drawable.file_user_line)
+                .setView(userAgreementBinding.root)
+                .setCancelable(false)
+                .create()
 
         val constraintSet = ConstraintSet()
         constraintSet.clone(userAgreementBinding.userAgreement)
@@ -245,7 +250,9 @@ class MainActivity : AppCompatActivity() {
                         SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐和其他贡献者\n\n版本：" + packageManager.getPackageInfo(
                             packageName, 0
                         ).let {
-                            @Suppress("DEPRECATION") it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
+                            @Suppress("DEPRECATION")
+                            it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+                                it.longVersionCode else it.versionCode) + ")"
                         } + "\n\nSince 2023.8.9\n\nLicensed under AGPL v3\n\n" + "开源地址")
                     val urlSpan = URLSpan("https://github.com/klxiaoniu/QQVersionList")
                     message.setSpan(
@@ -254,15 +261,19 @@ class MainActivity : AppCompatActivity() {
                         message.length,
                         SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
                     )
-                    MaterialAlertDialogBuilder(this).setTitle("关于")
-                        .setIcon(R.drawable.information_line).setMessage(message)
+                    val aboutDialog = MaterialAlertDialogBuilder(this)
+                        .setTitle("关于")
+                        .setIcon(R.drawable.information_line)
+                        .setMessage(message)
                         .setPositiveButton("确定", null)
                         .setNegativeButton("撤回同意用户协议") { _, _ ->
                             showUADialog(true)
-                        }.show().apply {
+                        }.create().apply {
                             findViewById<TextView>(android.R.id.message)?.movementMethod =
                                 LinkMovementMethodCompat.getInstance()
                         }
+
+                    aboutDialog.show()
                     true
                 }
 
@@ -356,9 +367,12 @@ class MainActivity : AppCompatActivity() {
 //            }
 
 
-            val dialogGuess = MaterialAlertDialogBuilder(this).setTitle("猜版 for Android")
-                .setIcon(R.drawable.search_line).setView(dialogGuessBinding.root)
-                .setCancelable(false).create()
+            val dialogGuess = MaterialAlertDialogBuilder(this)
+                .setTitle("猜版 for Android")
+                .setIcon(R.drawable.search_line)
+                .setView(dialogGuessBinding.root)
+                .setCancelable(false)
+                .create()
 
             dialogGuess.show()
 
@@ -367,6 +381,8 @@ class MainActivity : AppCompatActivity() {
                 dialogGuessBinding.etVersionBig.clearFocus()
                 dialogGuessBinding.spinnerVersion.clearFocus()
                 dialogGuessBinding.etVersionSmall.clearFocus()
+                val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                imm.hideSoftInputFromWindow(dialogGuessBinding.spinnerVersion.windowToken, 0)
 
                 try {
                     val versionBig = dialogGuessBinding.etVersionBig.editText?.text.toString()
@@ -460,7 +476,9 @@ class MainActivity : AppCompatActivity() {
         var status = STATUS_ONGOING
 
         val progressDialog =
-            MaterialAlertDialogBuilder(this).setView(dialogLoadingBinding.root).setCancelable(false)
+            MaterialAlertDialogBuilder(this)
+                .setView(dialogLoadingBinding.root)
+                .setCancelable(false)
                 .create()
 
         fun updateProgressDialogMessage(newMessage: String) {
@@ -507,10 +525,12 @@ class MainActivity : AppCompatActivity() {
                                 status = STATUS_PAUSE
                                 runOnUiThread {
                                     val successMaterialDialog =
-                                        MaterialAlertDialogBuilder(this).setTitle("猜测成功")
+                                        MaterialAlertDialogBuilder(this)
+                                            .setTitle("猜测成功")
                                             .setMessage("下载地址：$link")
                                             .setIcon(R.drawable.check_circle)
-                                            .setView(successButtonBinding.root).setCancelable(false)
+                                            .setView(successButtonBinding.root)
+                                            .setCancelable(false)
                                             .show()
 
                                     // 复制并停止按钮点击事件

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -33,15 +33,11 @@ import android.text.SpannableString
 import android.text.TextWatcher
 import android.text.style.URLSpan
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsAnimationCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -246,10 +242,11 @@ class MainActivity : AppCompatActivity() {
 
                 R.id.btn_about -> {
                     val message =
-                        SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐\n\n版本：" + packageManager.getPackageInfo(
+                        SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐和其他贡献者\n\n版本：" + packageManager.getPackageInfo(
                             packageName, 0
                         ).let {
-                            @Suppress("DEPRECATION") it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
+                            @Suppress("DEPRECATION")
+                            it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
                         } + "\n\nSince 2023.8.9\n\nLicensed under AGPL v3\n\n" + "开源地址")
                     val urlSpan = URLSpan("https://github.com/klxiaoniu/QQVersionList")
                     message.setSpan(
@@ -350,12 +347,12 @@ class MainActivity : AppCompatActivity() {
                 }
             })
 
-            dialogGuessBinding.spinnerVersion.setOnFocusChangeListener { _, hasFocus ->
-                if (hasFocus) {
-                    val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-                    imm.hideSoftInputFromWindow(dialogGuessBinding.spinnerVersion.windowToken, 0)
-                }
-            }
+//            dialogGuessBinding.spinnerVersion.setOnFocusChangeListener { _, hasFocus ->
+//                if (hasFocus) {
+//                    val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+//                    imm.hideSoftInputFromWindow(dialogGuessBinding.spinnerVersion.windowToken, 0)
+//                }
+//            }
 
 
             val dialogGuess = MaterialAlertDialogBuilder(this).setTitle("猜版 for Android")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -245,8 +245,7 @@ class MainActivity : AppCompatActivity() {
                         SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐和其他贡献者\n\n版本：" + packageManager.getPackageInfo(
                             packageName, 0
                         ).let {
-                            @Suppress("DEPRECATION")
-                            it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
+                            @Suppress("DEPRECATION") it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
                         } + "\n\nSince 2023.8.9\n\nLicensed under AGPL v3\n\n" + "开源地址")
                     val urlSpan = URLSpan("https://github.com/klxiaoniu/QQVersionList")
                     message.setSpan(
@@ -277,8 +276,10 @@ class MainActivity : AppCompatActivity() {
                         progressSize.isChecked = SpUtil.getBoolean("progressSize", false)
                     }
 
-                    val dialogSetting = MaterialAlertDialogBuilder(this).setTitle("设置")
-                        .setIcon(R.drawable.settings_line).setView(dialogSettingBinding.root)
+                    val dialogSetting = MaterialAlertDialogBuilder(this)
+                        .setTitle("设置")
+                        .setIcon(R.drawable.settings_line)
+                        .setView(dialogSettingBinding.root)
                         .create()
                     dialogSetting.show()
 

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -39,6 +39,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -74,6 +77,12 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        // 不加这段代码的话 Google 可能会在系统栏加遮罩
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+            window.isStatusBarContrastEnforced = false
+        }
         binding = ActivityMainBinding.inflate(layoutInflater)
 
         setContentView(binding.root)
@@ -84,7 +93,6 @@ class MainActivity : AppCompatActivity() {
             addItemDecoration(VerticalSpaceItemDecoration(dpToPx(5)))
         }
         initButtons()
-
     }
 
     private fun Context.dpToPx(dp: Int): Int {
@@ -119,12 +127,9 @@ class MainActivity : AppCompatActivity() {
         //用户协议，传参内容表示先前是否同意过协议
         val userAgreementBinding = UserAgreementBinding.inflate(layoutInflater)
 
-        val dialogUA = MaterialAlertDialogBuilder(this)
-            .setTitle("用户协议")
-            .setIcon(R.drawable.file_user_line)
-            .setView(userAgreementBinding.root)
-            .setCancelable(false)
-            .create()
+        val dialogUA =
+            MaterialAlertDialogBuilder(this).setTitle("用户协议").setIcon(R.drawable.file_user_line)
+                .setView(userAgreementBinding.root).setCancelable(false).create()
 
         val constraintSet = ConstraintSet()
         constraintSet.clone(userAgreementBinding.userAgreement)
@@ -244,9 +249,7 @@ class MainActivity : AppCompatActivity() {
                         SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐\n\n版本：" + packageManager.getPackageInfo(
                             packageName, 0
                         ).let {
-                            @Suppress("DEPRECATION")
-                            it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
-                                it.longVersionCode else it.versionCode) + ")"
+                            @Suppress("DEPRECATION") it.versionName + "(" + (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) it.longVersionCode else it.versionCode) + ")"
                         } + "\n\nSince 2023.8.9\n\nLicensed under AGPL v3\n\n" + "开源地址")
                     val urlSpan = URLSpan("https://github.com/klxiaoniu/QQVersionList")
                     message.setSpan(
@@ -277,10 +280,8 @@ class MainActivity : AppCompatActivity() {
                         progressSize.isChecked = SpUtil.getBoolean("progressSize", false)
                     }
 
-                    val dialogSetting = MaterialAlertDialogBuilder(this)
-                        .setTitle("设置")
-                        .setIcon(R.drawable.settings_line)
-                        .setView(dialogSettingBinding.root)
+                    val dialogSetting = MaterialAlertDialogBuilder(this).setTitle("设置")
+                        .setIcon(R.drawable.settings_line).setView(dialogSettingBinding.root)
                         .create()
                     dialogSetting.show()
 
@@ -357,12 +358,9 @@ class MainActivity : AppCompatActivity() {
             }
 
 
-            val dialogGuess = MaterialAlertDialogBuilder(this)
-                .setTitle("猜版 for Android")
-                .setIcon(R.drawable.search_line)
-                .setView(dialogGuessBinding.root)
-                .setCancelable(false)
-                .create()
+            val dialogGuess = MaterialAlertDialogBuilder(this).setTitle("猜版 for Android")
+                .setIcon(R.drawable.search_line).setView(dialogGuessBinding.root)
+                .setCancelable(false).create()
 
             dialogGuess.show()
 
@@ -463,10 +461,9 @@ class MainActivity : AppCompatActivity() {
 
         var status = STATUS_ONGOING
 
-        val progressDialog = MaterialAlertDialogBuilder(this)
-            .setView(dialogLoadingBinding.root)
-            .setCancelable(false)
-            .create()
+        val progressDialog =
+            MaterialAlertDialogBuilder(this).setView(dialogLoadingBinding.root).setCancelable(false)
+                .create()
 
         fun updateProgressDialogMessage(newMessage: String) {
             dialogLoadingBinding.loadingMessage.text = newMessage
@@ -512,12 +509,10 @@ class MainActivity : AppCompatActivity() {
                                 status = STATUS_PAUSE
                                 runOnUiThread {
                                     val successMaterialDialog =
-                                        MaterialAlertDialogBuilder(this)
-                                            .setTitle("猜测成功")
+                                        MaterialAlertDialogBuilder(this).setTitle("猜测成功")
                                             .setMessage("下载地址：$link")
                                             .setIcon(R.drawable.check_circle)
-                                            .setView(successButtonBinding.root)
-                                            .setCancelable(false)
+                                            .setView(successButtonBinding.root).setCancelable(false)
                                             .show()
 
                                     // 复制并停止按钮点击事件

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -75,7 +75,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         list[adapterPosition].displayType = 1
                         notifyItemChanged(adapterPosition)
                     }
-                    binding.tvContent.setOnLongClickListener {
+                    binding.itemAll.setOnLongClickListener {
                         if (SpUtil.getBoolean("longPressCard", true)) {
                             showDialog(
                                 it.context, list[adapterPosition].jsonString.toPrettyFormat()
@@ -102,7 +102,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         list[adapterPosition].displayType = 0
                         notifyItemChanged(adapterPosition)
                     }
-                    binding.tvDesc.setOnLongClickListener {
+                    binding.itemAllDetail.setOnLongClickListener {
                         if (SpUtil.getBoolean("longPressCard", true)) {
                             showDialog(
                                 it.context, list[adapterPosition].jsonString.toPrettyFormat()

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
@@ -19,6 +19,7 @@
 package com.xiaoniu.qqversionlist.util
 
 import android.app.Activity
+import android.app.AlertDialog
 import android.widget.Toast
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.xiaoniu.qqversionlist.R
@@ -33,14 +34,22 @@ object InfoUtil {
 
     fun Activity.dialogError(e: Exception) {
         runOnUiThread {
-            MaterialAlertDialogBuilder(this)
-                .setTitle("程序出错，请前往GitHub反馈")
-                .setIcon(R.drawable.error_warning_line)
-                .setMessage(e.stackTraceToString())
-                .setPositiveButton("确定", null)
-                .setNeutralButton("复制") { _, _ ->
-                    copyText(""+e.stackTraceToString())
-                }.show()
+
+            val errorDialog =
+                MaterialAlertDialogBuilder(this)
+                    .setTitle("程序出错，可前往 GitHub 反馈")
+                    .setIcon(R.drawable.error_warning_line)
+                    .setMessage(e.stackTraceToString())
+                    .setPositiveButton("确定", null)
+                    .setCancelable(false)
+                    .setNeutralButton("复制", null)
+                    .create()
+
+            errorDialog.getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                copyText("" + e.stackTraceToString())
+            }
+
+            errorDialog.show()
         }
     }
 

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -22,6 +22,7 @@
     android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_all"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="10dp">

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -24,6 +24,7 @@
     android:backgroundTint="?android:colorBackground">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/item_all_detail"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
- 修复：去除可能存在的系统栏遮罩
- 优化：去除点击猜版 Spinner 就隐藏软键盘的逻辑
- 其他更改：关于页作者添加“其他贡献者”文字
- 修复：版本列表部分文字区域无法触发长按动作的问题
- 优化：猜版对话框点击开始后关闭软键盘
- 优化：出现错误后出现的对话框，点击复制按钮后不再自动关闭对话框