### PR TITLE
分享字符串添加风险提示，上游更新：Gradle、Kotlin和Splash Screen，新增DataStore

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="2.0.0-RC1" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,17 +68,19 @@ android {
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.13.0-rc01")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.core:core-splashscreen:1.0.0")
+    implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("com.google.android.material:material:1.12.0-rc01")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.databinding:databinding-common:8.3.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("io.coil-kt:coil:2.6.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.0-rc01")
+    implementation("androidx.datastore:datastore-preferences-rxjava2:1.1.0-rc01")
+    implementation("androidx.datastore:datastore-preferences-rxjava3:1.1.0-rc01")
+    // implementation("com.tencent:mmkv:1.3.4")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,7 +80,4 @@ dependencies {
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("io.coil-kt:coil:2.6.0")
     implementation("androidx.datastore:datastore-preferences:1.1.0-rc01")
-    implementation("androidx.datastore:datastore-preferences-rxjava2:1.1.0-rc01")
-    implementation("androidx.datastore:datastore-preferences-rxjava3:1.1.0-rc01")
-    // implementation("com.tencent:mmkv:1.3.4")
 }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -652,10 +652,10 @@ class MainActivity : AppCompatActivity() {
                                                     Intent.EXTRA_TEXT,
                                                     if (appSize != "Error" && appSize != "-0.00" && appSize != "0.00") {
                                                         if (mode == MODE_OFFICIAL) "Android QQ $versionBig 正式版（大小：$appSize MB）\n\n下载地址：$link"
-                                                        else "Android QQ $versionBig.$vSmall 测试版（大小：$appSize MB）\n\n下载地址：$link"
+                                                        else "Android QQ $versionBig.$vSmall 测试版（大小：$appSize MB）\n\n下载地址：$link\n\n鉴于 QQ 测试版可能存在不可预知的稳定性问题，您在下载及使用该测试版本之前，必须明确并确保自身具备足够的风险识别和承受能力。"
                                                     } else {
                                                         if (mode == MODE_OFFICIAL) "Android QQ $versionBig 正式版\n\n下载地址：$link"
-                                                        else "Android QQ $versionBig.$vSmall 测试版\n\n下载地址：$link"
+                                                        else "Android QQ $versionBig.$vSmall 测试版\n\n下载地址：$link\n\n鉴于 QQ 测试版可能存在不可预知的稳定性问题，您在下载及使用该测试版本之前，必须明确并确保自身具备足够的风险识别和承受能力。"
                                                     }
                                                 )
                                             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.3.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.23" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0-RC1" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 30 10:08:40 CST 2024
+#Tue Apr 09 19:38:08 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### 优化

- 优化：分享字符串添加风险提示

### 上游更新

- Gradle 更新至 `8.7`
- Kotlin 更新至 `2.0.0-RC1`
- SplashScreen（`androidx.core:core-splashscreen`）更新至 `1.0.1`
- 新增 Jetpack DataStore（`androidx.datastore:datastore-preferences`）`1.1.0-rc01`（QQ Ver. Tool 相关持久化存储逻辑代码还未开始迁移）