### PR TITLE
删除“其他贡献者”（因为贡献者不是作者），基本完成SP到Jetpack DataStore的迁移，上游更新，更改版本列表“大小”文案

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,28 +71,28 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
 
   - 默认情况下，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
-    - 在设置中打开扩展测试版猜版格式后，软件将尝试访问以下链接：
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB2.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB3.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB1_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB2_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB3_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD2.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD3.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD2_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
-      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
+  - 在设置中打开扩展测试版猜版格式后，软件将尝试访问以下链接：
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB2.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB3.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB1_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB2_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB3_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD2.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD3.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD2_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
       
-      若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
+    若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
 访问成功后，软件会弹出成功对话框，对话框下方提供了一系列动作按钮，依次是“分享”、“下载”、“停止”、“跳过”和“复制”。
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
   - 默认情况下，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
   - 在设置中打开扩展测试版猜版格式后，软件将尝试访问以下链接：
+
+    <details>
+    <summary>点击展开</summary>
+    
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
@@ -91,6 +95,8 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
+
+    </details>
       
     若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
-        若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
+      若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
 访问成功后，软件会弹出成功对话框，对话框下方提供了一系列动作按钮，依次是“分享”、“下载”、“停止”、“跳过”和“复制”。
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
 对话框含有三个输入框，分别是“主版本号”、“版本”和“小版本号”。“主版本号”已经预填入了版本列表显示的最新版本号，也可自行修改。
 
 - 若选择猜正式版，无需填写小版本号，软件将尝试访问以下链接：
-
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB.apk`
     - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB1.apk`
@@ -92,6 +91,7 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
         - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
+      
       若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
 访问成功后，软件会弹出成功对话框，对话框下方提供了一系列动作按钮，依次是“分享”、“下载”、“停止”、“跳过”和“复制”。

--- a/README.md
+++ b/README.md
@@ -57,40 +57,40 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
 对话框含有三个输入框，分别是“主版本号”、“版本”和“小版本号”。“主版本号”已经预填入了版本列表显示的最新版本号，也可自行修改。
 
 - 若选择猜正式版，无需填写小版本号，软件将尝试访问以下链接：
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB1.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB2.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB3.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB_64.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB1_64.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB2_64.apk`
-    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB3_64.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB1.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB2.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB3.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB_64.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB1_64.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB2_64.apk`
+  - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB3_64.apk`
 
 - 若选择猜测试版，则需要填写起始小版本号：
 
-    - 默认情况下，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
+  - 默认情况下，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
     - 在设置中打开扩展测试版猜版格式后，软件将尝试访问以下链接：
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB2.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB3.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB1_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB2_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB3_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD2.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD3.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD2_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
-        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB2.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB3.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB1_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB2_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB3_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD2.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD3.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD2_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
+      - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
       
       若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,43 @@ QQ 版本列表实用工具 for Android 是一个使用 Material 3 组件库构�
 
 对话框含有三个输入框，分别是“主版本号”、“版本”和“小版本号”。“主版本号”已经预填入了版本列表显示的最新版本号，也可自行修改。
 
-若选择猜正式版，无需填写小版本号，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64.apk` 和 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB.apk` 。
+- 若选择猜正式版，无需填写小版本号，软件将尝试访问以下链接：
 
-若选择猜测试版，则需要填写起始小版本号，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB1.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB2.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_64_HB3.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB1_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB2_64.apk`
+    - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>_HB3_64.apk`
+
+- 若选择猜测试版，则需要填写起始小版本号：
+
+    - 默认情况下，软件将尝试访问 `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk` ，若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
+
+    - 在设置中打开扩展测试版猜版格式后，软件将尝试访问以下链接：
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB1.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB2.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HB3.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB1_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB2_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HB3_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD2.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD3.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD2_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD3_64.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_64_HD1HB.apk`
+        - `https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_<主版本号>.<小版本号>_HD1HB_64.apk`
+        若当次访问未果，默认情况下将按照设置逻辑自动递增小版本号后再次尝试访问，直到访问成功为止。
 
 访问成功后，软件会弹出成功对话框，对话框下方提供了一系列动作按钮，依次是“分享”、“下载”、“停止”、“跳过”和“复制”。
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = gitCommitCount
-        versionName = "1.2.4-$gitCommitHash"
+        versionName = "1.2.5-$gitCommitHash"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -69,6 +69,7 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.13.0-rc01")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("com.google.android.material:material:1.12.0-rc01")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/TipTimeApplication.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/TipTimeApplication.kt
@@ -21,6 +21,7 @@ package com.xiaoniu.qqversionlist
 import android.app.Application
 import com.google.android.material.color.DynamicColors
 
+
 class TipTimeApplication : Application() {
     companion object {
         lateinit var instance: TipTimeApplication
@@ -31,5 +32,13 @@ class TipTimeApplication : Application() {
         DynamicColors.applyToActivitiesIfAvailable(this)
         instance = this
         super.onCreate()
+        /*
+        val rootDir = MMKV.initialize(this)
+        println("mmkv root: $rootDir")
+
+        if (!MMKVUtil.getBoolean("migration_completed", false)) {
+              MMKVUtil.importSPToMMKV()
+              MMKVUtil.putBoolean("migration_completed", true) // 设置迁移完成标志
+        }*/
     }
 }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -245,7 +245,7 @@ class MainActivity : AppCompatActivity() {
 
                 R.id.btn_about -> {
                     val message =
-                        SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐和其他贡献者\n\n版本：" + packageManager.getPackageInfo(
+                        SpannableString("QQ 版本列表实用工具 for Android\n\n作者：快乐小牛、有鲫雪狐\n\n版本：" + packageManager.getPackageInfo(
                             packageName, 0
                         ).let {
                             @Suppress("DEPRECATION")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -214,9 +214,11 @@ class MainActivity : AppCompatActivity() {
                             versionAdapter.setData(qqVersion)
                             // 舍弃 currentQQVersion = qqVersion.first().versionNumber
                             // 大版本号也放持久化存储了，否则猜版 Shortcut 因为加载过快而获取不到东西
-                            DataStoreUtil.putString(
-                                "versionBig", qqVersion.first().versionNumber
-                            )
+                            lifecycleScope.launch {
+                                DataStoreUtil.putStringAsync(
+                                    "versionBig", qqVersion.first().versionNumber
+                                )
+                            }
                         }
 
                     }
@@ -362,7 +364,9 @@ class MainActivity : AppCompatActivity() {
             dialogGuessBinding.spinnerVersion.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(p0: Editable?) {
                     val judgeVerSelect = dialogGuessBinding.spinnerVersion.text.toString()
-                    DataStoreUtil.putString("versionSelect", judgeVerSelect)
+                    lifecycleScope.launch {
+                        DataStoreUtil.putStringAsync("versionSelect", judgeVerSelect)
+                    }
                     if (judgeVerSelect == "测试版" || judgeVerSelect == "空格版") {
                         dialogGuessBinding.etVersionSmall.isEnabled = true
                         dialogGuessBinding.guessDialogWarning.visibility = View.VISIBLE

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -55,9 +56,9 @@ import com.xiaoniu.qqversionlist.databinding.DialogSettingBinding
 import com.xiaoniu.qqversionlist.databinding.SuccessButtonBinding
 import com.xiaoniu.qqversionlist.databinding.UserAgreementBinding
 import com.xiaoniu.qqversionlist.util.ClipboardUtil.copyText
+import com.xiaoniu.qqversionlist.util.DataStoreUtil
 import com.xiaoniu.qqversionlist.util.InfoUtil.dialogError
 import com.xiaoniu.qqversionlist.util.InfoUtil.showToast
-import com.xiaoniu.qqversionlist.util.SpUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -152,13 +153,17 @@ class MainActivity : AppCompatActivity() {
         constraintSet.applyTo(userAgreementBinding.userAgreement)
 
         userAgreementBinding.uaButtonAgree.setOnClickListener {
-            SpUtil.putInt("userAgreement", 1)
+            lifecycleScope.launch {
+                DataStoreUtil.putIntAsync("userAgreement", 1)
+            }
             dialogUA.dismiss()
         }
 
         userAgreementBinding.uaButtonDisagree.setOnClickListener {
-            SpUtil.putInt("userAgreement", 0)
-            finish() // 不同意直接退出程序
+            lifecycleScope.launch {
+                DataStoreUtil.putIntAsync("userAgreement", 0)
+                finish() // 不同意直接退出程序
+            }
         }
         if (agreed) userAgreementBinding.uaButtonDisagree.text = "撤回同意并退出"
 
@@ -168,11 +173,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun initButtons() {
         // 删除 version Shared Preferences
-        SpUtil.deleteSp("version")
+        lifecycleScope.launch {
+            DataStoreUtil.deletePreferenceAsync("version")
+        }
 
         //这里的“getInt: userAgreement”的值代表着用户协议修订版本，后续更新协议版本后也需要在下面一行把“judgeUARead”+1，以此类推
         val judgeUARead = 1
-        if (SpUtil.getInt("userAgreement", 0) != judgeUARead) showUADialog(false)
+        if (DataStoreUtil.getInt("userAgreement", 0) != judgeUARead) showUADialog(false)
 
         // 进度条动画
         // https://github.com/material-components/material-components-android/blob/master/docs/components/ProgressIndicator.md
@@ -207,7 +214,7 @@ class MainActivity : AppCompatActivity() {
                             versionAdapter.setData(qqVersion)
                             // 舍弃 currentQQVersion = qqVersion.first().versionNumber
                             // 大版本号也放持久化存储了，否则猜版 Shortcut 因为加载过快而获取不到东西
-                            SpUtil.putString(
+                            DataStoreUtil.putString(
                                 "versionBig", qqVersion.first().versionNumber
                             )
                         }
@@ -278,12 +285,13 @@ class MainActivity : AppCompatActivity() {
                     val dialogSettingBinding = DialogSettingBinding.inflate(layoutInflater)
 
                     dialogSettingBinding.apply {
-                        switchDisplayFirst.isChecked = SpUtil.getBoolean("displayFirst", true)
-                        longPressCard.isChecked = SpUtil.getBoolean("longPressCard", true)
-                        guessNot5.isChecked = SpUtil.getBoolean("guessNot5", false)
-                        progressSize.isChecked = SpUtil.getBoolean("progressSize", false)
+                        switchDisplayFirst.isChecked =
+                            DataStoreUtil.getBoolean("displayFirst", true)
+                        longPressCard.isChecked = DataStoreUtil.getBoolean("longPressCard", true)
+                        guessNot5.isChecked = DataStoreUtil.getBoolean("guessNot5", false)
+                        progressSize.isChecked = DataStoreUtil.getBoolean("progressSize", false)
                         switchGuessTestExtend.isChecked =
-                            SpUtil.getBoolean("guessTestExtend", false) // 扩展测试版猜版格式
+                            DataStoreUtil.getBoolean("guessTestExtend", false) // 扩展测试版猜版格式
                     }
 
                     val dialogSetting = MaterialAlertDialogBuilder(this)
@@ -298,21 +306,31 @@ class MainActivity : AppCompatActivity() {
                             dialogSetting.dismiss()
                         }
                         switchDisplayFirst.setOnCheckedChangeListener { _, isChecked ->
-                            SpUtil.putBoolean("displayFirst", isChecked)
-                            getData()
+                            lifecycleScope.launch {
+                                DataStoreUtil.putBooleanAsync("displayFirst", isChecked)
+                                getData()
+                            }
                         }
                         longPressCard.setOnCheckedChangeListener { _, isChecked ->
-                            SpUtil.putBoolean("longPressCard", isChecked)
+                            lifecycleScope.launch {
+                                DataStoreUtil.putBooleanAsync("longPressCard", isChecked)
+                            }
                         }
                         guessNot5.setOnCheckedChangeListener { _, isChecked ->
-                            SpUtil.putBoolean("guessNot5", isChecked)
+                            lifecycleScope.launch {
+                                DataStoreUtil.putBooleanAsync("guessNot5", isChecked)
+                            }
                         }
                         progressSize.setOnCheckedChangeListener { _, isChecked ->
-                            SpUtil.putBoolean("progressSize", isChecked)
-                            getData()
+                            lifecycleScope.launch {
+                                DataStoreUtil.putBooleanAsync("progressSize", isChecked)
+                                getData()
+                            }
                         }
                         switchGuessTestExtend.setOnCheckedChangeListener { _, isChecked ->
-                            SpUtil.putBoolean("guessTestExtend", isChecked)
+                            lifecycleScope.launch {
+                                DataStoreUtil.putBooleanAsync("guessTestExtend", isChecked)
+                            }
                         }
                     }
 
@@ -326,10 +344,10 @@ class MainActivity : AppCompatActivity() {
 
         fun showGuessVersionDialog() {
             val dialogGuessBinding = DialogGuessBinding.inflate(layoutInflater)
-            val verBig = SpUtil.getString("versionBig", "")
+            val verBig = DataStoreUtil.getString("versionBig", "")
             dialogGuessBinding.etVersionBig.editText?.setText(verBig)
 
-            val memVersion = SpUtil.getString("versionSelect", "正式版")
+            val memVersion = DataStoreUtil.getString("versionSelect", "正式版")
             if (memVersion == "测试版" || memVersion == "空格版" || memVersion == "正式版") {
                 dialogGuessBinding.spinnerVersion.setText(memVersion, false)
             }
@@ -344,7 +362,7 @@ class MainActivity : AppCompatActivity() {
             dialogGuessBinding.spinnerVersion.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(p0: Editable?) {
                     val judgeVerSelect = dialogGuessBinding.spinnerVersion.text.toString()
-                    SpUtil.putString("versionSelect", judgeVerSelect)
+                    DataStoreUtil.putString("versionSelect", judgeVerSelect)
                     if (judgeVerSelect == "测试版" || judgeVerSelect == "空格版") {
                         dialogGuessBinding.etVersionSmall.isEnabled = true
                         dialogGuessBinding.guessDialogWarning.visibility = View.VISIBLE
@@ -375,12 +393,9 @@ class MainActivity : AppCompatActivity() {
                 .setIcon(R.drawable.search_line)
                 .setView(dialogGuessBinding.root)
                 .setCancelable(false)
-                .create()
-
-            dialogGuess.show()
+                .show()
 
             dialogGuessBinding.btnGuessStart.setOnClickListener {
-
                 dialogGuessBinding.etVersionBig.clearFocus()
                 dialogGuessBinding.spinnerVersion.clearFocus()
                 dialogGuessBinding.etVersionSmall.clearFocus()
@@ -395,12 +410,14 @@ class MainActivity : AppCompatActivity() {
                         versionSmall =
                             dialogGuessBinding.etVersionSmall.editText?.text.toString().toInt()
                     }
-                    if (versionSmall % 5 != 0 && !SpUtil.getBoolean(
+                    if (versionSmall % 5 != 0 && !DataStoreUtil.getBoolean(
                             "guessNot5", false
                         )
                     ) throw Exception("小版本号需填 5 的倍数。如有需求，请前往设置解除此限制。")
                     if (versionSmall != 0) {
-                        SpUtil.putInt("versionSmall", versionSmall)
+                        lifecycleScope.launch {
+                            DataStoreUtil.putIntAsync("versionSmall", versionSmall)
+                        }
                     }/*我偷懒了，因为我上面也有偷懒逻辑，
                        为了防止 null，我在正式版猜版时默认填入了 0，
                        但是我没处理下面涉及到持久化存储逻辑的语句，就把 0 存进去了，
@@ -420,14 +437,14 @@ class MainActivity : AppCompatActivity() {
             }
 
 
-            val memVersionSmall = SpUtil.getInt("versionSmall", -1)
+            val memVersionSmall = DataStoreUtil.getInt("versionSmall", -1)
             if (memVersionSmall != -1) {
                 dialogGuessBinding.etVersionSmall.editText?.setText(memVersionSmall.toString())
             }
 
         }
 
-        if (intent.action == "android.intent.action.VIEW" && SpUtil.getInt(
+        if (intent.action == "android.intent.action.VIEW" && DataStoreUtil.getInt(
                 "userAgreement", 0
             ) == judgeUARead
         ) {
@@ -497,13 +514,13 @@ class MainActivity : AppCompatActivity() {
                     when (status) {
                         STATUS_ONGOING -> {
                             if (mode == MODE_TEST) {
-                                if (link == "" || !SpUtil.getBoolean(
+                                if (link == "" || !DataStoreUtil.getBoolean(
                                         "guessTestExtend",
                                         false
                                     )
                                 ) link =
                                     "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64.apk"
-                                else if (SpUtil.getBoolean("guessTestExtend", false)) {
+                                else if (DataStoreUtil.getBoolean("guessTestExtend", false)) {
                                     if (link.endsWith("_64.apk") && !link.endsWith("_HB_64.apk") && !link.endsWith(
                                             "_HB1_64.apk"
                                         ) && !link.endsWith("_HB2_64.apk") && !link.endsWith("_HB3_64.apk") && !link.endsWith(
@@ -591,61 +608,65 @@ class MainActivity : AppCompatActivity() {
                             val success = response.isSuccessful
                             if (success) {
                                 status = STATUS_PAUSE
-                                runOnUiThread {
-                                    successButtonBinding.root.parent?.let { parent ->
-                                        if (parent is ViewGroup) {
-                                            parent.removeView(successButtonBinding.root)
+                                getFileSizeInMB(link) { appSize ->
+                                    runOnUiThread {
+                                        successButtonBinding.root.parent?.let { parent ->
+                                            if (parent is ViewGroup) {
+                                                parent.removeView(successButtonBinding.root)
+                                            }
                                         }
-                                    }
 
-                                    val successMaterialDialog = MaterialAlertDialogBuilder(this)
-                                        .setTitle("猜测成功")
-                                        .setMessage("下载地址：$link")
-                                        .setIcon(R.drawable.check_circle)
-                                        .setView(successButtonBinding.root)
-                                        .setCancelable(false)
-                                        .show()
+                                        val successMaterialDialog = MaterialAlertDialogBuilder(this)
+                                            .setTitle("猜测成功")
+                                            .setMessage("下载地址：$link")
+                                            .setIcon(R.drawable.check_circle)
+                                            .setView(successButtonBinding.root)
+                                            .setCancelable(false)
+                                            .apply {
+                                                if (appSize != "Error" && appSize != "-0.00" && appSize != "0.00") setMessage(
+                                                    "下载地址：$link\n\n大小：$appSize MB"
+                                                )
+                                                else setMessage("下载地址：$link")
+                                            }.show()
 
 
-                                    // 复制并停止按钮点击事件
-                                    successButtonBinding.btnCopy.setOnClickListener {
-                                        copyText(link)
-                                        successMaterialDialog.dismiss()
-                                        status = STATUS_END
-                                    }
+                                        // 复制并停止按钮点击事件
+                                        successButtonBinding.btnCopy.setOnClickListener {
+                                            copyText(link)
+                                            successMaterialDialog.dismiss()
+                                            status = STATUS_END
+                                        }
 
-                                    // 继续按钮点击事件
-                                    successButtonBinding.btnContinue.setOnClickListener {
-                                        // 测试版情况下，未打开扩展猜版或扩展猜版到最后一步时执行小版本号的递增
-                                        if (mode == MODE_TEST && (!SpUtil.getBoolean(
-                                                "guessTestExtend",
-                                                false
-                                            ) || link.endsWith("_HD1HB_64.apk"))
-                                        ) vSmall += if (!SpUtil.getBoolean(
-                                                "guessNot5",
-                                                false
-                                            )
-                                        ) 5 else 1
-                                        else if (mode == MODE_UNOFFICIAL) vSmall += if (!SpUtil.getBoolean(
-                                                "guessNot5",
-                                                false
-                                            )
-                                        ) 5 else 1
-                                        successMaterialDialog.dismiss()
-                                        status = STATUS_ONGOING
-                                    }
+                                        // 继续按钮点击事件
+                                        successButtonBinding.btnContinue.setOnClickListener {
+                                            // 测试版情况下，未打开扩展猜版或扩展猜版到最后一步时执行小版本号的递增
+                                            if (mode == MODE_TEST && (!DataStoreUtil.getBoolean(
+                                                    "guessTestExtend",
+                                                    false
+                                                ) || link.endsWith("_HD1HB_64.apk"))
+                                            ) vSmall += if (!DataStoreUtil.getBoolean(
+                                                    "guessNot5",
+                                                    false
+                                                )
+                                            ) 5 else 1
+                                            else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
+                                                    "guessNot5",
+                                                    false
+                                                )
+                                            ) 5 else 1
+                                            successMaterialDialog.dismiss()
+                                            status = STATUS_ONGOING
+                                        }
 
-                                    // 停止按钮点击事件
-                                    successButtonBinding.btnStop.setOnClickListener {
-                                        successMaterialDialog.dismiss()
-                                        status = STATUS_END
-                                    }
+                                        // 停止按钮点击事件
+                                        successButtonBinding.btnStop.setOnClickListener {
+                                            successMaterialDialog.dismiss()
+                                            status = STATUS_END
+                                        }
 
-                                    // 分享按钮点击事件
-                                    successButtonBinding.btnShare.setOnClickListener {
-                                        successMaterialDialog.dismiss()
-
-                                        getFileSizeInMB(link) { appSize ->
+                                        // 分享按钮点击事件
+                                        successButtonBinding.btnShare.setOnClickListener {
+                                            successMaterialDialog.dismiss()
                                             val shareIntent = Intent(Intent.ACTION_SEND).apply {
                                                 type = "text/plain"
                                                 putExtra(
@@ -666,37 +687,41 @@ class MainActivity : AppCompatActivity() {
                                             )
                                             status = STATUS_END
                                         }
-                                    }
 
-                                    // 下载按钮点击事件
-                                    successButtonBinding.btnDownload.setOnClickListener {
-                                        val request1 = DownloadManager.Request(Uri.parse(link))
-                                        if (mode == MODE_TEST || mode == MODE_UNOFFICIAL) {
-                                            request1.setDestinationInExternalPublicDir(
-                                                Environment.DIRECTORY_DOWNLOADS,
-                                                "Android_QQ_${versionBig}.${vSmall}_64.apk"
-                                            )
-                                        } else if (mode == MODE_OFFICIAL) {
-                                            request1.setDestinationInExternalPublicDir(
-                                                Environment.DIRECTORY_DOWNLOADS,
-                                                "Android_QQ_${versionBig}_64.apk"
-                                            )
+                                        // 下载按钮点击事件
+                                        successButtonBinding.btnDownload.setOnClickListener {
+                                            val requestDownload =
+                                                DownloadManager.Request(Uri.parse(link))
+                                            if (mode == MODE_TEST || mode == MODE_UNOFFICIAL) {
+                                                requestDownload.setDestinationInExternalPublicDir(
+                                                    Environment.DIRECTORY_DOWNLOADS,
+                                                    "Android_QQ_${versionBig}.${vSmall}_64.apk"
+                                                )
+                                            } else if (mode == MODE_OFFICIAL) {
+                                                requestDownload.setDestinationInExternalPublicDir(
+                                                    Environment.DIRECTORY_DOWNLOADS,
+                                                    "Android_QQ_${versionBig}_64.apk"
+                                                )
+                                            }
+                                            val downloadManager =
+                                                getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+                                            downloadManager.enqueue(requestDownload)
+                                            successMaterialDialog.dismiss()
+                                            status = STATUS_END
                                         }
-                                        val downloadManager =
-                                            getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-                                        downloadManager.enqueue(request1)
-                                        successMaterialDialog.dismiss()
-                                        status = STATUS_END
                                     }
-
                                 }
                             } else {
-                                if (mode == MODE_TEST && (!SpUtil.getBoolean(
+                                if (mode == MODE_TEST && (!DataStoreUtil.getBoolean(
                                         "guessTestExtend",
                                         false
                                     ) || link.endsWith("_HD1HB_64.apk")) // 测试版情况下，未打开扩展猜版或扩展猜版到最后一步时执行小版本号的递增
-                                ) vSmall += if (!SpUtil.getBoolean("guessNot5", false)) 5 else 1
-                                else if (mode == MODE_UNOFFICIAL) vSmall += if (!SpUtil.getBoolean(
+                                ) vSmall += if (!DataStoreUtil.getBoolean(
+                                        "guessNot5",
+                                        false
+                                    )
+                                ) 5 else 1
+                                else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
                                         "guessNot5",
                                         false
                                     )

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -33,7 +33,7 @@ import com.xiaoniu.qqversionlist.R
 import com.xiaoniu.qqversionlist.data.QQVersionBean
 import com.xiaoniu.qqversionlist.databinding.ItemVersionBinding
 import com.xiaoniu.qqversionlist.databinding.ItemVersionDetailBinding
-import com.xiaoniu.qqversionlist.util.SpUtil
+import com.xiaoniu.qqversionlist.util.DataStoreUtil
 import com.xiaoniu.qqversionlist.util.StringUtil.toPrettyFormat
 
 class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -45,7 +45,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         this.list.apply {
             clear()
             addAll(list)
-            val displayJudge = SpUtil.getBoolean("displayFirst", true)
+            val displayJudge = DataStoreUtil.getBoolean("displayFirst", true)
             if (displayJudge) {
                 first().displayType = 1 // 第一项默认展开
             }
@@ -76,7 +76,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         notifyItemChanged(adapterPosition)
                     }
                     binding.itemAll.setOnLongClickListener {
-                        if (SpUtil.getBoolean("longPressCard", true)) {
+                        if (DataStoreUtil.getBoolean("longPressCard", true)) {
                             showDialog(
                                 it.context, list[adapterPosition].jsonString.toPrettyFormat()
                             )
@@ -103,7 +103,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         notifyItemChanged(adapterPosition)
                     }
                     binding.itemAllDetail.setOnLongClickListener {
-                        if (SpUtil.getBoolean("longPressCard", true)) {
+                        if (DataStoreUtil.getBoolean("longPressCard", true)) {
                             showDialog(
                                 it.context, list[adapterPosition].jsonString.toPrettyFormat()
                             )
@@ -125,9 +125,10 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val bean = list[position]
         if (holder is ViewHolder) {
-            val result = "版本：" + bean.versionNumber + "\n大小：" + bean.size + " MB"
-            holder.binding.tvContent.text = result
-            if (!SpUtil.getBoolean("progressSize", false)) {
+            //val result = "版本：" + bean.versionNumber + "\n额定大小：" + bean.size + " MB"
+            holder.binding.tvVersion.text = "版本：" + bean.versionNumber
+            holder.binding.tvSize.text = "额定大小：" + bean.size + " MB"
+            if (!DataStoreUtil.getBoolean("progressSize", false)) {
                 holder.binding.listProgressLine.visibility = View.GONE
             } else {
                 holder.binding.listProgressLine.visibility = View.VISIBLE
@@ -147,7 +148,8 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         crossfade(200)
                     }
                 }
-                tvContentDetail.text = "版本：" + bean.versionNumber + "\n大小：" + bean.size + " MB"
+                tvDetailVersion.text = "版本：" + bean.versionNumber
+                tvDetailSize.text = "额定大小：" + bean.size + " MB"
                 tvTitle.text = bean.featureTitle
                 tvDesc.text = bean.summary.joinToString(separator = "\n- ", prefix = "- ")
                 tvPerSize.text =
@@ -157,7 +159,7 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         )
                     }%"
 
-                if (!SpUtil.getBoolean("progressSize", false)) {
+                if (!DataStoreUtil.getBoolean("progressSize", false)) {
                     holder.binding.listDetailProgressLine.visibility = View.GONE
                     holder.binding.tvPerSize.visibility = View.GONE
                 } else {

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
@@ -18,9 +18,24 @@
 
 package com.xiaoniu.qqversionlist.util
 
-import androidx.appcompat.app.AppCompatActivity
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.xiaoniu.qqversionlist.TipTimeApplication
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
 
+/* SharedPreferences
 object SpUtil {
     private fun getSp() =
         TipTimeApplication.instance.getSharedPreferences("data", AppCompatActivity.MODE_PRIVATE)
@@ -46,4 +61,167 @@ object SpUtil {
     fun deleteSp(key: String) =
         getSp().edit().remove(key).apply()
 
+}*/
+
+/*MMKV
+object MMKVUtil {
+    val mmkv by lazy {
+        MMKV.mmkvWithID("data", MMKV.MULTI_PROCESS_MODE)
+    }
+
+    fun importSPToMMKV() {
+        val oldSP =
+            TipTimeApplication.instance.getSharedPreferences("data", AppCompatActivity.MODE_PRIVATE)
+        mmkv.importFromSharedPreferences(oldSP)
+        oldSP.edit().clear().apply()
+    }
+
+    fun getInt(key: String, defValue: Int = 0): Int = mmkv.getInt(key, defValue)
+
+    fun putInt(key: String, value: Int) = mmkv.encode(key, value)
+
+    fun getString(key: String, defValue: String = ""): String? = mmkv.getString(key, defValue)
+
+    fun putString(key: String, value: String) = mmkv.encode(key, value)
+
+    fun getBoolean(key: String, defValue: Boolean): Boolean = mmkv.getBoolean(key, defValue)
+
+    fun putBoolean(key: String, value: Boolean) = mmkv.encode(key, value)
+
+    fun deleteMMKVKey(key: String) = mmkv.removeValueForKey(key)
+}*/
+
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "data",
+    produceMigrations = { context ->
+        listOf(
+            SharedPreferencesMigration(context, "data")
+        )
+    })
+
+object DataStoreUtil {
+
+    private val dataStore: DataStore<Preferences> by lazy {
+        TipTimeApplication.instance.dataStore
+    }
+
+    @Throws(IOException::class)
+    fun getInt(key: String, defValue: Int): Int {
+        return runBlocking {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[intPreferencesKey(key)] ?: defValue
+            } ?: defValue
+        }
+    }
+
+    @Throws(IOException::class)
+    fun putInt(key: String, value: Int) {
+        runBlocking {
+            dataStore.edit { preferences ->
+                preferences[intPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    fun getString(key: String, defValue: String): String {
+        return runBlocking {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[stringPreferencesKey(key)] ?: defValue
+            } ?: defValue
+        }
+    }
+
+    @Throws(IOException::class)
+    fun putString(key: String, value: String) {
+        runBlocking {
+            dataStore.edit { preferences ->
+                preferences[stringPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    fun getBoolean(key: String, defValue: Boolean): Boolean {
+        return runBlocking {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[booleanPreferencesKey(key)] ?: defValue
+            } ?: defValue
+        }
+    }
+
+    @Throws(IOException::class)
+    fun putBoolean(key: String, value: Boolean) {
+        runBlocking {
+            dataStore.edit { preferences ->
+                preferences[booleanPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    @Throws(IOException::class)
+    fun deletePreference(key: String) {
+        runBlocking {
+            dataStore.edit { preferences ->
+                preferences.remove(stringPreferencesKey(key))
+                preferences.remove(intPreferencesKey(key))
+                preferences.remove(booleanPreferencesKey(key))
+                preferences.remove(floatPreferencesKey(key))
+                preferences.remove(longPreferencesKey(key))
+                preferences.remove(doublePreferencesKey(key))
+            }
+        }
+    }
+
+    suspend fun getIntAsync(key: String, defValue: Int): Int {
+        return dataStore.data.firstOrNull()?.let { preferences ->
+            preferences[intPreferencesKey(key)] ?: defValue
+        } ?: defValue
+    }
+
+    suspend fun putIntAsync(key: String, value: Int) {
+        dataStore.edit { preferences ->
+            preferences[intPreferencesKey(key)] = value
+        }
+    }
+
+
+    suspend fun getStringAsync(key: String, defValue: String): String {
+        return dataStore.data.firstOrNull()?.let { preferences ->
+            preferences[stringPreferencesKey(key)] ?: defValue
+        } ?: defValue
+    }
+
+    suspend fun putStringAsync(key: String, value: String) {
+        dataStore.edit { preferences ->
+            preferences[stringPreferencesKey(key)] = value
+        }
+    }
+
+    suspend fun getBooleanAsync(key: String, defValue: Boolean): Boolean {
+        return dataStore.data.firstOrNull()?.let { preferences ->
+            preferences[booleanPreferencesKey(key)] ?: defValue
+        } ?: defValue
+    }
+
+
+    suspend fun putBooleanAsync(key: String, value: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[booleanPreferencesKey(key)] = value
+        }
+    }
+
+
+    suspend fun deletePreferenceAsync(key: String) {
+        dataStore.edit { preferences ->
+            preferences.remove(stringPreferencesKey(key))
+            preferences.remove(intPreferencesKey(key))
+            preferences.remove(booleanPreferencesKey(key))
+            preferences.remove(floatPreferencesKey(key))
+            preferences.remove(longPreferencesKey(key))
+            preferences.remove(doublePreferencesKey(key))
+        }
+    }
 }
+

--- a/app/src/main/res/layout/dialog_setting.xml
+++ b/app/src/main/res/layout/dialog_setting.xml
@@ -47,7 +47,7 @@
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
-        android:text="版本列表展示当前包大小占比最大包指示条" />
+        android:text="版本列表展示额定包大小占比历史最大包指示条" />
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/switch_guess_test_extend"

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -34,16 +34,36 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/tv_content"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintVertical_bias="0.5"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/ib_expand"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintVertical_bias="0.5"
-                tools:text="版本：9.0.25\n大小：307 MB"
-                app:layout_constraintVertical_chainStyle="packed" />
+                app:layout_constraintVertical_chainStyle="packed">
+
+                <TextView
+                    android:id="@+id/tv_version"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="版本：9.0.25"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    android:textSize="16sp"
+                    android:textColor="?attr/colorOnSurface"/>
+
+                <TextView
+                    android:id="@+id/tv_size"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="额定大小：307 MB"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_version" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <Button
                 android:id="@+id/ib_expand"

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -30,14 +30,34 @@
         android:orientation="vertical"
         android:padding="10dp">
 
-        <TextView
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tv_content_detail"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="@id/ib_collapse"
             app:layout_constraintEnd_toStartOf="@id/ib_collapse"
-            app:layout_constraintTop_toTopOf="@id/ib_collapse"
-            tools:text="版本：9.0.25\n大小：307 MB" />
+            app:layout_constraintTop_toTopOf="@id/ib_collapse">
+
+            <TextView
+                android:id="@+id/tv_detail_version"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="版本：9.0.25"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                android:textSize="16sp"
+                android:textColor="?attr/colorOnSurface"/>
+
+            <TextView
+                android:id="@+id/tv_detail_size"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="额定大小：307 MB"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_detail_version" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView
             android:id="@+id/tv_per_size"
@@ -45,7 +65,7 @@
             android:layout_height="match_parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_content_detail"
-            tools:text="占比历史最大包（）：" />
+            tools:text="占比历史额定最大包（）：" />
 
         <com.google.android.material.progressindicator.LinearProgressIndicator
             android:id="@+id/list_detail_progress_line"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.3.1" apply false
+    id("com.android.application") version "8.3.2" apply false
     id("org.jetbrains.kotlin.android") version "2.0.0-RC1" apply false
 }


### PR DESCRIPTION
- 其他更改：删除“其他贡献者”（因为贡献者不是作者）
- 优化：基本完成 SharedPreferences 到 Jetpack DataStore 的迁移，提供同步和异步读写方式，注释方式提供 MMKV 读写方式
- 上游更新：Android Gradle Plugin 更新至 8.3.2，新增 Jetpack Lifecycle（`androidx.lifecycle:lifecycle-runtime-ktx`）2.7.0
- 优化：更改版本列表“大小”文案为“额定大小”，“版本”文字适当放大
- 优化：猜版成功页新增大小显示