### PR TITLE
更改版本列表界面、修复RTL语言下布局问题、DataStore封装改为内部协程、用列表切换逻辑替换猜版矢代码

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.13.0-rc01")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.core:core-splashscreen:1.0.1")
+    implementation("androidx.core:core-splashscreen:1.1.0-rc01")
     implementation("com.google.android.material:material:1.12.0-rc01")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -41,7 +41,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -486,7 +485,29 @@ class MainActivity : AppCompatActivity() {
         var link = ""
         val thread = Thread {
             var vSmall = versionSmall
+            val stList = listOf(
+                "_64",
+                "_64_HB",
+                "_64_HB1",
+                "_64_HB2",
+                "_64_HB3",
+                "_64_HD",
+                "_64_HD1",
+                "_64_HD2",
+                "_64_HD3",
+                "_64_HD1HB",
+                "_HB_64",
+                "_HB1_64",
+                "_HB2_64",
+                "_HB3_64",
+                "_HD_64",
+                "_HD1_64",
+                "_HD2_64",
+                "_HD3_64",
+                "_HD1HB_64"
+            )
             try {
+                var sIndex = 0
                 while (true) {
                     when (status) {
                         STATUS_ONGOING -> {
@@ -496,83 +517,37 @@ class MainActivity : AppCompatActivity() {
                                         false
                                     )
                                 ) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64.apk"
+                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}${stList[sIndex]}.apk"
                                 else if (DataStoreUtil.getBoolean("guessTestExtend", false)) {
-                                    if (link.endsWith("_64.apk") && !link.endsWith("_HB_64.apk") && !link.endsWith(
-                                            "_HB1_64.apk"
-                                        ) && !link.endsWith("_HB2_64.apk") && !link.endsWith("_HB3_64.apk") && !link.endsWith(
-                                            "_HD_64.apk"
-                                        ) && !link.endsWith("_HD1_64.apk") && !link.endsWith("_HD2_64.apk") && !link.endsWith(
-                                            "_HD3_64.apk"
-                                        ) && !link.endsWith("_HD1HB_64.apk")
-                                    ) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HB.apk"
-                                    else if (link.endsWith("_64_HB.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HB1.apk"
-                                    else if (link.endsWith("_64_HB1.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HB2.apk"
-                                    else if (link.endsWith("_64_HB2.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HB3.apk"
-                                    else if (link.endsWith("_64_HB3.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HB_64.apk"
-                                    else if (link.endsWith("_HB_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HB1_64.apk"
-                                    else if (link.endsWith("_HB1_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HB2_64.apk"
-                                    else if (link.endsWith("_HB2_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HB3_64.apk"
-                                    else if (link.endsWith("_HB3_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HD.apk"
-                                    else if (link.endsWith("_64_HD.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HD1.apk"
-                                    else if (link.endsWith("_64_HD1.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HD2.apk"
-                                    else if (link.endsWith("_64_HD2.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HD3.apk"
-                                    else if (link.endsWith("_64_HD3.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64_HD1HB.apk"
-                                    else if (link.endsWith("_64_HD1HB.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HD_64.apk"
-                                    else if (link.endsWith("_HD_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HD1_64.apk"
-                                    else if (link.endsWith("_HD1_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HD2_64.apk"
-                                    else if (link.endsWith("_HD2_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HD3_64.apk"
-                                    else if (link.endsWith("_HD3_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_HD1HB_64.apk"
-                                    else if (link.endsWith("_HD1HB_64.apk")) link =
-                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_$versionBig.${vSmall}_64.apk"
+                                    sIndex += 1
+                                    link =
+                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}.${vSmall}${stList[sIndex]}.apk"
                                 }
                             } else if (mode == MODE_UNOFFICIAL) {
                                 link =
                                     "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android%20$versionBig.${vSmall}%2064.apk"
                             } else if (mode == MODE_OFFICIAL) {
+                                val soList = listOf(
+                                    "_64",
+                                    "_64_HB",
+                                    "_64_HB1",
+                                    "_64_HB2",
+                                    "_64_HB3",
+                                    "_HB_64",
+                                    "_HB1_64",
+                                    "_HB2_64",
+                                    "_HB3_64"
+                                )
                                 if (link == "") link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64.apk"
-                                else if (link.endsWith("_64.apk") && !link.endsWith("_HB_64.apk") && !link.endsWith(
-                                        "_HB1_64.apk"
-                                    ) && !link.endsWith("_HB2_64.apk") && !link.endsWith("_HB3_64.apk")
-                                ) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64_HB.apk"
-                                else if (link.endsWith("_64_HB.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64_HB1.apk"
-                                else if (link.endsWith("_64_HB1.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64_HB2.apk"
-                                else if (link.endsWith("_64_HB2.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_64_HB3.apk"
-                                else if (link.endsWith("_64_HB3.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_HB_64.apk"
-                                else if (link.endsWith("_HB_64.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_HB1_64.apk"
-                                else if (link.endsWith("_HB1_64.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_HB2_64.apk"
-                                else if (link.endsWith("_HB2_64.apk")) link =
-                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}_HB3_64.apk"
-                                else if (link.endsWith("_HB3_64.apk")) {
+                                    "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}${soList[sIndex]}.apk"
+                                else if (sIndex == (soList.size - 1)) {
                                     status = STATUS_END
                                     showToast("未猜测到包")
                                     continue
+                                } else {
+                                    sIndex += 1
+                                    link =
+                                        "https://downv6.qq.com/qqweb/QQ_1/android_apk/Android_${versionBig}${soList[sIndex]}.apk"
                                 }
 
                             }
@@ -620,13 +595,15 @@ class MainActivity : AppCompatActivity() {
                                             if (mode == MODE_TEST && (!DataStoreUtil.getBoolean(
                                                     "guessTestExtend",
                                                     false
-                                                ) || link.endsWith("_HD1HB_64.apk"))
-                                            ) vSmall += if (!DataStoreUtil.getBoolean(
-                                                    "guessNot5",
-                                                    false
-                                                )
-                                            ) 5 else 1
-                                            else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
+                                                ) || sIndex == (stList.size - 1))
+                                            ) {
+                                                vSmall += if (!DataStoreUtil.getBoolean(
+                                                        "guessNot5",
+                                                        false
+                                                    )
+                                                ) 5 else 1
+                                                sIndex = 0
+                                            } else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
                                                     "guessNot5",
                                                     false
                                                 )
@@ -692,13 +669,15 @@ class MainActivity : AppCompatActivity() {
                                 if (mode == MODE_TEST && (!DataStoreUtil.getBoolean(
                                         "guessTestExtend",
                                         false
-                                    ) || link.endsWith("_HD1HB_64.apk")) // 测试版情况下，未打开扩展猜版或扩展猜版到最后一步时执行小版本号的递增
-                                ) vSmall += if (!DataStoreUtil.getBoolean(
-                                        "guessNot5",
-                                        false
-                                    )
-                                ) 5 else 1
-                                else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
+                                    ) || sIndex == (stList.size - 1)) // 测试版情况下，未打开扩展猜版或扩展猜版到最后一步时执行小版本号的递增
+                                ) {
+                                    vSmall += if (!DataStoreUtil.getBoolean(
+                                            "guessNot5",
+                                            false
+                                        )
+                                    ) 5 else 1
+                                    sIndex = 0
+                                } else if (mode == MODE_UNOFFICIAL) vSmall += if (!DataStoreUtil.getBoolean(
                                         "guessNot5",
                                         false
                                     )
@@ -712,6 +691,7 @@ class MainActivity : AppCompatActivity() {
 
                         STATUS_END -> {
                             if (mode != MODE_OFFICIAL) showToast("已停止猜测")
+                            sIndex = 0
                             progressDialog.dismiss()
                             break
                         }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -153,17 +153,13 @@ class MainActivity : AppCompatActivity() {
         constraintSet.applyTo(userAgreementBinding.userAgreement)
 
         userAgreementBinding.uaButtonAgree.setOnClickListener {
-            lifecycleScope.launch {
-                DataStoreUtil.putIntAsync("userAgreement", 1)
-            }
+            DataStoreUtil.putIntAsync("userAgreement", 1)
             dialogUA.dismiss()
         }
 
         userAgreementBinding.uaButtonDisagree.setOnClickListener {
-            lifecycleScope.launch {
-                DataStoreUtil.putIntAsync("userAgreement", 0)
-                finish() // 不同意直接退出程序
-            }
+            DataStoreUtil.putIntAsync("userAgreement", 0)
+            finish()
         }
         if (agreed) userAgreementBinding.uaButtonDisagree.text = "撤回同意并退出"
 
@@ -173,9 +169,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun initButtons() {
         // 删除 version Shared Preferences
-        lifecycleScope.launch {
-            DataStoreUtil.deletePreferenceAsync("version")
-        }
+        DataStoreUtil.deletePreferenceAsync("version")
 
         //这里的“getInt: userAgreement”的值代表着用户协议修订版本，后续更新协议版本后也需要在下面一行把“judgeUARead”+1，以此类推
         val judgeUARead = 1
@@ -214,11 +208,9 @@ class MainActivity : AppCompatActivity() {
                             versionAdapter.setData(qqVersion)
                             // 舍弃 currentQQVersion = qqVersion.first().versionNumber
                             // 大版本号也放持久化存储了，否则猜版 Shortcut 因为加载过快而获取不到东西
-                            lifecycleScope.launch {
-                                DataStoreUtil.putStringAsync(
-                                    "versionBig", qqVersion.first().versionNumber
-                                )
-                            }
+                            DataStoreUtil.putStringAsync(
+                                "versionBig", qqVersion.first().versionNumber
+                            )
                         }
 
                     }
@@ -308,31 +300,21 @@ class MainActivity : AppCompatActivity() {
                             dialogSetting.dismiss()
                         }
                         switchDisplayFirst.setOnCheckedChangeListener { _, isChecked ->
-                            lifecycleScope.launch {
-                                DataStoreUtil.putBooleanAsync("displayFirst", isChecked)
-                                getData()
-                            }
+                            DataStoreUtil.putBooleanAsync("displayFirst", isChecked)
+                            getData()
                         }
                         longPressCard.setOnCheckedChangeListener { _, isChecked ->
-                            lifecycleScope.launch {
-                                DataStoreUtil.putBooleanAsync("longPressCard", isChecked)
-                            }
+                            DataStoreUtil.putBooleanAsync("longPressCard", isChecked)
                         }
                         guessNot5.setOnCheckedChangeListener { _, isChecked ->
-                            lifecycleScope.launch {
-                                DataStoreUtil.putBooleanAsync("guessNot5", isChecked)
-                            }
+                            DataStoreUtil.putBooleanAsync("guessNot5", isChecked)
                         }
                         progressSize.setOnCheckedChangeListener { _, isChecked ->
-                            lifecycleScope.launch {
-                                DataStoreUtil.putBooleanAsync("progressSize", isChecked)
-                                getData()
-                            }
+                            DataStoreUtil.putBooleanAsync("progressSize", isChecked)
+                            getData()
                         }
                         switchGuessTestExtend.setOnCheckedChangeListener { _, isChecked ->
-                            lifecycleScope.launch {
-                                DataStoreUtil.putBooleanAsync("guessTestExtend", isChecked)
-                            }
+                            DataStoreUtil.putBooleanAsync("guessTestExtend", isChecked)
                         }
                     }
 
@@ -348,7 +330,6 @@ class MainActivity : AppCompatActivity() {
             val dialogGuessBinding = DialogGuessBinding.inflate(layoutInflater)
             val verBig = DataStoreUtil.getString("versionBig", "")
             dialogGuessBinding.etVersionBig.editText?.setText(verBig)
-
             val memVersion = DataStoreUtil.getString("versionSelect", "正式版")
             if (memVersion == "测试版" || memVersion == "空格版" || memVersion == "正式版") {
                 dialogGuessBinding.spinnerVersion.setText(memVersion, false)
@@ -364,9 +345,7 @@ class MainActivity : AppCompatActivity() {
             dialogGuessBinding.spinnerVersion.addTextChangedListener(object : TextWatcher {
                 override fun afterTextChanged(p0: Editable?) {
                     val judgeVerSelect = dialogGuessBinding.spinnerVersion.text.toString()
-                    lifecycleScope.launch {
-                        DataStoreUtil.putStringAsync("versionSelect", judgeVerSelect)
-                    }
+                    DataStoreUtil.putStringAsync("versionSelect", judgeVerSelect)
                     if (judgeVerSelect == "测试版" || judgeVerSelect == "空格版") {
                         dialogGuessBinding.etVersionSmall.isEnabled = true
                         dialogGuessBinding.guessDialogWarning.visibility = View.VISIBLE
@@ -419,9 +398,7 @@ class MainActivity : AppCompatActivity() {
                         )
                     ) throw Exception("小版本号需填 5 的倍数。如有需求，请前往设置解除此限制。")
                     if (versionSmall != 0) {
-                        lifecycleScope.launch {
-                            DataStoreUtil.putIntAsync("versionSmall", versionSmall)
-                        }
+                        DataStoreUtil.putIntAsync("versionSmall", versionSmall)
                     }/*我偷懒了，因为我上面也有偷懒逻辑，
                        为了防止 null，我在正式版猜版时默认填入了 0，
                        但是我没处理下面涉及到持久化存储逻辑的语句，就把 0 存进去了，
@@ -440,21 +417,17 @@ class MainActivity : AppCompatActivity() {
                 dialogGuess.dismiss()
             }
 
-
             val memVersionSmall = DataStoreUtil.getInt("versionSmall", -1)
             if (memVersionSmall != -1) {
                 dialogGuessBinding.etVersionSmall.editText?.setText(memVersionSmall.toString())
             }
-
         }
-
         if (intent.action == "android.intent.action.VIEW" && DataStoreUtil.getInt(
                 "userAgreement", 0
             ) == judgeUARead
         ) {
             showGuessVersionDialog()
         }
-
         binding.btnGuess.setOnClickListener {
             showGuessVersionDialog()
         }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -40,6 +40,10 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val list = mutableListOf<QQVersionBean>()
 
+    private fun Context.dpToPx(dp: Int): Int {
+        return (dp * resources.displayMetrics.density).toInt()
+    }
+
     @SuppressLint("NotifyDataSetChanged")
     fun setData(list: List<QQVersionBean>) {
         this.list.apply {
@@ -130,11 +134,25 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             holder.binding.tvSize.text = bean.size + " MB"
             if (!DataStoreUtil.getBoolean("progressSize", false)) {
                 holder.binding.listProgressLine.visibility = View.GONE
+                holder.binding.tvPerSizeCard.visibility = View.GONE
+                val layoutParams =
+                    holder.binding.tvSizeCard.layoutParams as? ViewGroup.MarginLayoutParams
+                        ?: return
+                layoutParams.marginEnd = holder.itemView.context.dpToPx(0)
+                holder.binding.tvSizeCard.layoutParams = layoutParams
             } else {
                 holder.binding.listProgressLine.visibility = View.VISIBLE
+                holder.binding.tvPerSizeCard.visibility = View.VISIBLE
+                val layoutParams =
+                    holder.binding.tvSizeCard.layoutParams as? ViewGroup.MarginLayoutParams
+                        ?: return
+                layoutParams.marginEnd = holder.itemView.context.dpToPx(6)
+                holder.binding.tvSizeCard.layoutParams = layoutParams
                 holder.binding.listProgressLine.max =
                     ((list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 10).toInt()
                 holder.binding.listProgressLine.progress = (bean.size.toFloat() * 10).toInt()
+                holder.binding.tvPerSizeText.text =
+                    "${"%.2f".format(bean.size.toFloat() / (list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 100)}%"
             }
         } else if (holder is ViewHolderDetail) {
             holder.binding.apply {
@@ -160,13 +178,27 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                             bean.size.toFloat() / (list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 100
                         )
                     }%"
+                tvOldPerSizeText.text =
+                    "${"%.2f".format(bean.size.toFloat() / (list.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 100)}%"
 
                 if (!DataStoreUtil.getBoolean("progressSize", false)) {
                     holder.binding.listDetailProgressLine.visibility = View.GONE
                     holder.binding.tvPerSize.visibility = View.GONE
+                    holder.binding.tvOldPerSizeCard.visibility = View.GONE
+                    val layoutParams =
+                        holder.binding.tvOldSizeCard.layoutParams as? ViewGroup.MarginLayoutParams
+                            ?: return
+                    layoutParams.marginEnd = holder.itemView.context.dpToPx(0)
+                    holder.binding.tvOldSizeCard.layoutParams = layoutParams
                 } else {
                     holder.binding.listDetailProgressLine.visibility = View.VISIBLE
                     holder.binding.tvPerSize.visibility = View.VISIBLE
+                    holder.binding.tvOldPerSizeCard.visibility = View.VISIBLE
+                    val layoutParams =
+                        holder.binding.tvOldSizeCard.layoutParams as? ViewGroup.MarginLayoutParams
+                            ?: return
+                    layoutParams.marginEnd = holder.itemView.context.dpToPx(6)
+                    holder.binding.tvOldSizeCard.layoutParams = layoutParams
                     holder.binding.listDetailProgressLine.max =
                         ((list.maxByOrNull { it.size.toFloat() }?.size?.toFloat()
                             ?: 0f) * 10).toInt()

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -126,8 +126,8 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         val bean = list[position]
         if (holder is ViewHolder) {
             //val result = "版本：" + bean.versionNumber + "\n额定大小：" + bean.size + " MB"
-            holder.binding.tvVersion.text = "版本：" + bean.versionNumber
-            holder.binding.tvSize.text = "额定大小：" + bean.size + " MB"
+            holder.binding.tvVersion.text = bean.versionNumber
+            holder.binding.tvSize.text = bean.size + " MB"
             if (!DataStoreUtil.getBoolean("progressSize", false)) {
                 holder.binding.listProgressLine.visibility = View.GONE
             } else {
@@ -148,6 +148,8 @@ class VersionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                         crossfade(200)
                     }
                 }
+                tvOldVersion.text = bean.versionNumber
+                tvOldSize.text = bean.size + " MB"
                 tvDetailVersion.text = "版本：" + bean.versionNumber
                 tvDetailSize.text = "额定大小：" + bean.size + " MB"
                 tvTitle.text = bean.featureTitle

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/SpUtil.kt
@@ -32,7 +32,12 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.xiaoniu.qqversionlist.TipTimeApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /* SharedPreferences
@@ -101,7 +106,6 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
     })
 
 object DataStoreUtil {
-
     private val dataStore: DataStore<Preferences> by lazy {
         TipTimeApplication.instance.dataStore
     }
@@ -174,53 +178,69 @@ object DataStoreUtil {
         }
     }
 
-    suspend fun getIntAsync(key: String, defValue: Int): Int {
-        return dataStore.data.firstOrNull()?.let { preferences ->
-            preferences[intPreferencesKey(key)] ?: defValue
-        } ?: defValue
-    }
 
-    suspend fun putIntAsync(key: String, value: Int) {
-        dataStore.edit { preferences ->
-            preferences[intPreferencesKey(key)] = value
+    fun getIntAsync(key: String, defValue: Int): Deferred<Int> {
+        return CoroutineScope(Dispatchers.IO).async {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[intPreferencesKey(key)] ?: defValue
+            } ?: defValue
         }
     }
 
 
-    suspend fun getStringAsync(key: String, defValue: String): String {
-        return dataStore.data.firstOrNull()?.let { preferences ->
-            preferences[stringPreferencesKey(key)] ?: defValue
-        } ?: defValue
-    }
-
-    suspend fun putStringAsync(key: String, value: String) {
-        dataStore.edit { preferences ->
-            preferences[stringPreferencesKey(key)] = value
-        }
-    }
-
-    suspend fun getBooleanAsync(key: String, defValue: Boolean): Boolean {
-        return dataStore.data.firstOrNull()?.let { preferences ->
-            preferences[booleanPreferencesKey(key)] ?: defValue
-        } ?: defValue
-    }
-
-
-    suspend fun putBooleanAsync(key: String, value: Boolean) {
-        dataStore.edit { preferences ->
-            preferences[booleanPreferencesKey(key)] = value
+    fun putIntAsync(key: String, value: Int) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.edit { preferences ->
+                preferences[intPreferencesKey(key)] = value
+            }
         }
     }
 
 
-    suspend fun deletePreferenceAsync(key: String) {
-        dataStore.edit { preferences ->
-            preferences.remove(stringPreferencesKey(key))
-            preferences.remove(intPreferencesKey(key))
-            preferences.remove(booleanPreferencesKey(key))
-            preferences.remove(floatPreferencesKey(key))
-            preferences.remove(longPreferencesKey(key))
-            preferences.remove(doublePreferencesKey(key))
+    fun getStringAsync(key: String, defValue: String): Deferred<String> {
+        return CoroutineScope(Dispatchers.IO).async {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[stringPreferencesKey(key)] ?: defValue
+            } ?: defValue
+        }
+    }
+
+    fun putStringAsync(key: String, value: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.edit { preferences ->
+                preferences[stringPreferencesKey(key)] = value
+            }
+        }
+    }
+
+    fun getBooleanAsync(key: String, defValue: Boolean): Deferred<Boolean> {
+        return CoroutineScope(Dispatchers.IO).async {
+            dataStore.data.firstOrNull()?.let { preferences ->
+                preferences[booleanPreferencesKey(key)] ?: defValue
+            } ?: defValue
+        }
+    }
+
+
+    fun putBooleanAsync(key: String, value: Boolean) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.edit { preferences ->
+                preferences[booleanPreferencesKey(key)] = value
+            }
+        }
+    }
+
+
+    fun deletePreferenceAsync(key: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            dataStore.edit { preferences ->
+                preferences.remove(stringPreferencesKey(key))
+                preferences.remove(intPreferencesKey(key))
+                preferences.remove(booleanPreferencesKey(key))
+                preferences.remove(floatPreferencesKey(key))
+                preferences.remove(longPreferencesKey(key))
+                preferences.remove(doublePreferencesKey(key))
+            }
         }
     }
 }

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -36,32 +36,53 @@
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/tv_content"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintVertical_bias="0.5"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/ib_expand"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintVertical_bias="0.5"
                 app:layout_constraintVertical_chainStyle="packed">
 
                 <TextView
                     android:id="@+id/tv_version"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    tools:text="版本：9.0.25"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    android:textSize="16sp"
-                    android:textColor="?attr/colorOnSurface"/>
-
-                <TextView
-                    android:id="@+id/tv_size"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    tools:text="额定大小：307 MB"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:textColor="?attr/colorOnSurface"
+                    android:textSize="24sp"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_version" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="9.0.25" />
+
+                <com.google.android.material.card.MaterialCardView
+                    style="?attr/materialCardViewFilledStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="?attr/colorSecondaryContainer"
+                    app:cardCornerRadius="4dp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_version">
+
+                    <TextView
+                        android:id="@+id/tv_size"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:layout_marginEnd="2dp"
+                        android:padding="4dp"
+                        android:textColor="?attr/colorOnSecondaryContainer"
+                        android:textSize="10sp"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/tv_version"
+                        tools:text="307 MB" />
+
+                </com.google.android.material.card.MaterialCardView>
+
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -58,8 +58,8 @@
                     tools:text="9.0.25" />
 
                 <com.google.android.material.card.MaterialCardView
-                    style="?attr/materialCardViewFilledStyle"
                     android:id="@+id/tv_per_size_card"
+                    style="?attr/materialCardViewFilledStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:backgroundTint="?attr/colorSecondaryContainer"
@@ -89,9 +89,9 @@
                     style="?attr/materialCardViewFilledStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="6dp"
                     android:backgroundTint="?attr/colorSecondaryContainer"
                     app:cardCornerRadius="4dp"
-                    android:layout_marginEnd="6dp"
                     app:layout_constraintBottom_toBottomOf="@id/tv_version"
                     app:layout_constraintEnd_toStartOf="@id/tv_per_size_card"
                     app:layout_constraintTop_toTopOf="@id/tv_version">

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -49,9 +49,9 @@
                     android:id="@+id/tv_version"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="4dp"
-                    android:layout_marginEnd="4dp"
-                    android:textColor="?attr/colorOnSurface"
+                    android:layout_marginStart="6dp"
+                    android:layout_marginEnd="6dp"
+                    android:textColor="?attr/colorOnPrimaryContainer"
                     android:textSize="24sp"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
@@ -59,12 +59,41 @@
 
                 <com.google.android.material.card.MaterialCardView
                     style="?attr/materialCardViewFilledStyle"
+                    android:id="@+id/tv_per_size_card"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:backgroundTint="?attr/colorSecondaryContainer"
                     app:cardCornerRadius="4dp"
                     app:layout_constraintBottom_toBottomOf="@id/tv_version"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_version">
+
+                    <TextView
+                        android:id="@+id/tv_per_size_text"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:layout_marginEnd="2dp"
+                        android:padding="4dp"
+                        android:textColor="?attr/colorOnSecondaryContainer"
+                        android:textSize="10sp"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/tv_version"
+                        tools:text="75.47%" />
+
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/tv_size_card"
+                    style="?attr/materialCardViewFilledStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:backgroundTint="?attr/colorSecondaryContainer"
+                    app:cardCornerRadius="4dp"
+                    android:layout_marginEnd="6dp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                    app:layout_constraintEnd_toStartOf="@id/tv_per_size_card"
                     app:layout_constraintTop_toTopOf="@id/tv_version">
 
                     <TextView

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -44,9 +44,9 @@
                 android:id="@+id/tv_old_version"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:layout_marginEnd="4dp"
-                android:textColor="?attr/colorOnSurface"
+                android:layout_marginStart="6dp"
+                android:layout_marginEnd="6dp"
+                android:textColor="?attr/colorOnPrimaryContainer"
                 android:textSize="24sp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
@@ -54,12 +54,41 @@
 
             <com.google.android.material.card.MaterialCardView
                 style="?attr/materialCardViewFilledStyle"
+                android:id="@+id/tv_old_per_size_card"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:backgroundTint="?attr/colorSecondaryContainer"
                 app:cardCornerRadius="4dp"
                 app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_old_version">
+
+                <TextView
+                    android:id="@+id/tv_old_per_size_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:layout_marginEnd="2dp"
+                    android:padding="4dp"
+                    android:textColor="?attr/colorOnSecondaryContainer"
+                    android:textSize="10sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_old_version"
+                    tools:text="75.47%" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tv_old_size_card"
+                style="?attr/materialCardViewFilledStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:backgroundTint="?attr/colorSecondaryContainer"
+                app:cardCornerRadius="4dp"
+                android:layout_marginEnd="6dp"
+                app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                app:layout_constraintEnd_toStartOf="@id/tv_old_per_size_card"
                 app:layout_constraintTop_toTopOf="@id/tv_old_version">
 
                 <TextView
@@ -85,6 +114,7 @@
             android:id="@+id/tv_detail_version"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textColor="?attr/colorOnSecondaryContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/ib_collapse"
             tools:text="版本：9.0.25" />
@@ -93,6 +123,7 @@
             android:id="@+id/tv_detail_size"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:textColor="?attr/colorOnSecondaryContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_detail_version"
             tools:text="额定大小：307 MB" />
@@ -101,6 +132,7 @@
             android:id="@+id/tv_per_size"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
+            android:textColor="?attr/colorOnSecondaryContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_detail_size"
             tools:text="占比历史额定最大包（）：" />
@@ -121,6 +153,7 @@
             android:id="@+id/tv_title"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
+            android:textColor="?attr/colorOnSecondaryContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/list_detail_progress_line"
             tools:text="体验说明：" />
@@ -130,6 +163,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingBottom="6dp"
+            android:textColor="?attr/colorOnSecondaryContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_title"
             tools:text="- 新年新“状态”\n- 文本文本文本" />

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -53,8 +53,8 @@
                 tools:text="9.0.25" />
 
             <com.google.android.material.card.MaterialCardView
-                style="?attr/materialCardViewFilledStyle"
                 android:id="@+id/tv_old_per_size_card"
+                style="?attr/materialCardViewFilledStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:backgroundTint="?attr/colorSecondaryContainer"
@@ -84,9 +84,9 @@
                 style="?attr/materialCardViewFilledStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="6dp"
                 android:backgroundTint="?attr/colorSecondaryContainer"
                 app:cardCornerRadius="4dp"
-                android:layout_marginEnd="6dp"
                 app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
                 app:layout_constraintEnd_toStartOf="@id/tv_old_per_size_card"
                 app:layout_constraintTop_toTopOf="@id/tv_old_version">

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -32,39 +32,77 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tv_content_detail"
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="@id/ib_collapse"
             app:layout_constraintEnd_toStartOf="@id/ib_collapse"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/ib_collapse">
 
             <TextView
-                android:id="@+id/tv_detail_version"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:text="版本：9.0.25"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                android:textSize="16sp"
-                android:textColor="?attr/colorOnSurface"/>
-
-            <TextView
-                android:id="@+id/tv_detail_size"
+                android:id="@+id/tv_old_version"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                tools:text="额定大小：307 MB"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="4dp"
+                android:textColor="?attr/colorOnSurface"
+                android:textSize="24sp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_detail_version" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="9.0.25" />
+
+            <com.google.android.material.card.MaterialCardView
+                style="?attr/materialCardViewFilledStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:backgroundTint="?attr/colorSecondaryContainer"
+                app:cardCornerRadius="4dp"
+                app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/tv_old_version">
+
+                <TextView
+                    android:id="@+id/tv_old_size"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:layout_marginEnd="2dp"
+                    android:padding="4dp"
+                    android:textColor="?attr/colorOnSecondaryContainer"
+                    android:textSize="10sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_old_version"
+                    tools:text="307 MB" />
+
+            </com.google.android.material.card.MaterialCardView>
+
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <TextView
+            android:id="@+id/tv_detail_version"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/ib_collapse"
+            tools:text="版本：9.0.25" />
+
+        <TextView
+            android:id="@+id/tv_detail_size"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_version"
+            tools:text="额定大小：307 MB" />
 
         <TextView
             android:id="@+id/tv_per_size"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_content_detail"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail_size"
             tools:text="占比历史额定最大包（）：" />
 
         <com.google.android.material.progressindicator.LinearProgressIndicator


### PR DESCRIPTION
- 优化：更改版本列表界面（见附图），版本列表收折状态也能展示包占比数值
- 修复：RTL 语言下布局未正常跟随预期布局的问题
- 优化：Jetpack DataStore 异步封装改为内部协程
- 其他更改：用列表切换逻辑替换猜版矢代码
- 优化：调整了版本列表文字颜色
- 上游更新：Jetpack SplashScreen（`androidx.core:core-splashscreen`）更新至 1.1.0-rc01

![IMG_20240419_235034.jpg](https://github.com/klxiaoniu/QQVersionList/assets/139336664/4460877b-5703-401c-b831-0b4870164149)