### PR TITLE
fix: bottomappbar insets

### DIFF
--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Resources
+import android.graphics.Color
 import android.graphics.Rect
 import android.net.Uri
 import android.os.Build
@@ -41,6 +42,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -79,14 +83,25 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.collapsingToolbar, null)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.topAppBar.updatePadding(0, insets.top, 0, 0)
+            binding.bottomAppBar.updatePadding(0, 0, 0, insets.bottom)
+            windowInsets
+        }
+
         // 不加这段代码的话 Google 可能会在系统栏加遮罩
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             window.isNavigationBarContrastEnforced = false
             window.isStatusBarContrastEnforced = false
         }
-        binding = ActivityMainBinding.inflate(layoutInflater)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
 
-        setContentView(binding.root)
         versionAdapter = VersionAdapter()
         binding.rvContent.apply {
             adapter = versionAdapter

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,7 +21,6 @@
     android:id="@+id/coordinatorLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".ui.MainActivity">
 
     <androidx.recyclerview.widget.RecyclerView
@@ -42,10 +41,10 @@
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:fitsSystemWindows="true"
         app:layout_constraintTop_toTopOf="parent">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
+            android:id="@+id/collapsingToolbar"
             style="?attr/collapsingToolbarLayoutLargeStyle"
             android:layout_width="match_parent"
             android:layout_height="?attr/collapsingToolbarLayoutLargeSize"
@@ -68,7 +67,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:fitsSystemWindows="true"
         app:hideOnScroll="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:menu="@menu/bottom_app_bar" />
@@ -77,8 +75,8 @@
         android:id="@+id/btn_guess"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="猜版"
         android:minWidth="0dp"
+        android:text="猜版"
         app:icon="@drawable/search_line"
         app:layout_anchor="@id/bottomAppBar"
         app:removeEmbeddedFabElevation="true" />


### PR DESCRIPTION
## 这个 PR 解决了什么问题？

> 请补充以下信息

### 需求背景

安卓10及以下BottomAppBar被导航栏遮挡

### 更新日志

#### 修复

- 修复：安卓10及以下BottomAppBar边距问题

- before
![1](https://github.com/klxiaoniu/QQVersionList/assets/114972867/f50facd3-a16d-41f0-b666-dc937a2677fb)
after
![2](https://github.com/klxiaoniu/QQVersionList/assets/114972867/1412d0bb-f418-4c3b-a33a-ce374747d450)

## 自检清单

> 请检查下列所有选项并打勾

- [x] 此 PR 已实现我的所有预期更改，可以被合并。
- [x] 我确认此 PR 全部代码仅由本人（或联合作者）编写，代码所有权归本人（或联合作者）所有。
- [x] 此 PR 更新日志已提供（或无须提供）。
- [x] Readme 文档无须补充（或已补充）。
