### PR TITLE
上游更新、异步读取猜版后缀字符串、新增“已安装”标识

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-RC2" />
+    <option name="version" value="2.0.0-RC3" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="21" />
+  </component>
   <component name="KotlinJpsPluginSettings">
     <option name="version" value="2.0.0-RC3" />
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "21"
+        jvmTarget = "17"
     }
     buildFeatures {
         viewBinding = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = gitCommitCount
-        versionName = "1.2.7-$gitCommitHash"
+        versionName = "1.2.8-$gitCommitHash"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -56,11 +56,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
     buildFeatures {
         viewBinding = true
@@ -69,7 +69,7 @@ android {
 }
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.13.0")
+    implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.core:core-splashscreen:1.1.0-rc01")
@@ -81,5 +81,5 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("io.coil-kt:coil:2.6.0")
-    implementation("androidx.datastore:datastore-preferences:1.1.0-rc01")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
     buildFeatures {
         viewBinding = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,9 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
-        tools:ignore="QueryAllPackagesPermission" />
 
+    <queries>
+        <package android:name="com.tencent.mobileqq" />
+    </queries>
 
     <application
         android:name=".TipTimeApplication"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
 
     <application
         android:name=".TipTimeApplication"

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -21,7 +21,6 @@ package com.xiaoniu.qqversionlist.ui
 
 import android.app.DownloadManager
 import android.content.Context
-import androidx.core.content.pm.PackageInfoCompat
 import android.content.Intent
 import android.content.res.Configuration
 import android.content.res.Resources
@@ -40,12 +39,12 @@ import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.text.method.LinkMovementMethodCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -90,11 +89,13 @@ class MainActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
-            ViewCompat.setOnApplyWindowInsetsListener(binding.collapsingToolbar, null)
-            ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
-                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
-                // binding.topAppBar.updatePadding(0, insets.top, 0, 0)
+            ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
+                val insets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
+                view.setPadding(insets.left, 0, insets.right, 0)
                 binding.bottomAppBar.updatePadding(0, 0, 0, insets.bottom)
+                binding.btnGuess.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                    bottomMargin = insets.bottom / 2
+                }
                 windowInsets
             }
         }
@@ -233,8 +234,8 @@ class MainActivity : AppCompatActivity() {
                                 "贡献者：Col_or、bggRGjQaUbCoE\n" +
                                 "开源地址：GitHub\n" +
                                 "开源协议：AGPL v3\n" +
-                                "Since 2023.8.9\n" +
-                                "获取更新：GitHub Releases、Obtainium、九七通知中心"
+                                "获取更新：GitHub Releases、Obtainium、九七通知中心\n\n" +
+                                "Since 2023.8.9"
                     )
                     message.setSpan(
                         URLSpan("https://github.com/klxiaoniu"),

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -123,6 +123,10 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
                 tvVersion.text = bean.versionNumber
                 tvSize.text = bean.size + " MB"
                 bindProgress(listProgressLine, null, tvPerSizeText, tvPerSizeCard, tvSizeCard, bean)
+                if (DataStoreUtil.getString("QQVersionInstall", "") == bean.versionNumber) {
+                    tvInstallCard.isVisible = true
+                    tvInstall.text = "已安装"
+                } else tvInstallCard.isVisible = false
             }
         } else if (holder is ViewHolderDetail) {
             holder.binding.apply {
@@ -144,6 +148,11 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
                 tvDesc.text = bean.summary.joinToString(separator = "\n- ", prefix = "- ")
 
                 tvTitle.isVisible = tvTitle.text != ""
+
+                if (DataStoreUtil.getString("QQVersionInstall", "") == bean.versionNumber) {
+                    tvOldInstallCard.isVisible = true
+                    tvOldInstall.text = "已安装"
+                } else tvOldInstallCard.isVisible = false
 
                 bindProgress(
                     listDetailProgressLine,
@@ -190,6 +199,7 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
 
                 tvPerSizeText.text =
                     "${"%.2f".format(bean.size.toFloat() / (currentList.maxByOrNull { it.size.toFloat() }?.size?.toFloat() ?: 0f) * 100)}%"
+
             }
         }
 
@@ -203,7 +213,7 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
         }
         MaterialAlertDialogBuilder(context)
             .setView(tv)
-            .setTitle("Json 详情")
+            .setTitle("JSON 详情")
             .setIcon(R.drawable.braces_line)
             .show()
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,7 +41,8 @@
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.CollapsingToolbarLayout
             android:id="@+id/collapsingToolbar"

--- a/app/src/main/res/layout/dialog_setting.xml
+++ b/app/src/main/res/layout/dialog_setting.xml
@@ -40,7 +40,7 @@
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
         android:paddingBottom="8dp"
-        android:text="长按版本列表文字弹出详细信息" />
+        android:text="长按版本列表文字弹出源 JSON 字符串" />
 
     <com.google.android.material.materialswitch.MaterialSwitch
         android:id="@+id/progress_size"

--- a/app/src/main/res/layout/item_version.xml
+++ b/app/src/main/res/layout/item_version.xml
@@ -59,6 +59,34 @@
                     tools:text="9.0.25" />
 
                 <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/tv_install_card"
+                    style="?attr/materialCardViewFilledStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:backgroundTint="?attr/colorSecondaryContainer"
+                    app:cardCornerRadius="4dp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                    app:layout_constraintStart_toEndOf="@id/tv_version"
+                    app:layout_constraintTop_toTopOf="@id/tv_version">
+
+                    <TextView
+                        android:id="@+id/tv_install"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="2dp"
+                        android:layout_marginEnd="2dp"
+                        android:padding="4dp"
+                        android:textColor="?attr/colorOnSecondaryContainer"
+                        android:textSize="10sp"
+                        app:layout_constraintBottom_toBottomOf="@id/tv_version"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/tv_version"
+                        tools:text="已安装" />
+
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
                     android:id="@+id/tv_per_size_card"
                     style="?attr/materialCardViewFilledStyle"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_version_detail.xml
+++ b/app/src/main/res/layout/item_version_detail.xml
@@ -54,6 +54,34 @@
                 tools:text="9.0.25" />
 
             <com.google.android.material.card.MaterialCardView
+                android:id="@+id/tv_old_install_card"
+                style="?attr/materialCardViewFilledStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:backgroundTint="?attr/colorSecondaryContainer"
+                app:cardCornerRadius="4dp"
+                app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                app:layout_constraintStart_toEndOf="@id/tv_old_version"
+                app:layout_constraintTop_toTopOf="@id/tv_old_version">
+
+                <TextView
+                    android:id="@+id/tv_old_install"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:layout_marginEnd="2dp"
+                    android:padding="4dp"
+                    android:textColor="?attr/colorOnSecondaryContainer"
+                    android:textSize="10sp"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_old_version"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/tv_old_version"
+                    tools:text="已安装" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/tv_old_per_size_card"
                 style="?attr/materialCardViewFilledStyle"
                 android:layout_width="wrap_content"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.4.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.0-RC2" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0-RC3" apply false
 }


### PR DESCRIPTION
## 这个 PR 解决了什么问题？

> 请补充以下信息

### 需求背景

1. 设置-猜版后缀设置 是同步方法读取字符串，如果字符串过长可能造成 ANR。
2. 版本列表可以显示当前设备已经安装的 QQ 版本标识

### 更新日志

#### 新增

- 新增：“已安装”标识，可显示当前设备已经安装的 QQ 版本

#### 优化

- 优化：异步方法读取猜版后缀字符串持久化存储，防止潜在的 ANR

#### 其他更改

- 字符串“Json”更改为“JSON”，并对其所在文案进行了细微更改

#### 上游更改

- 更新：Kotlin 更新至 2.0.0-RC3
- 更新：Java 编译链更新至 Java 17
- 更新：Jetpack Android Core KTX（`androidx.core:core-ktx`）更新至 1.13.1
- 更新：Jetpack DataStore Preferences（`androidx.datastore:datastore-preferences`）更新至 1.1.1

## 自检清单

> 请检查下列所有选项并打勾

- [x] 此 PR 已实现我的所有预期更改，可以被合并。
- [x] 我确认此 PR 全部代码仅由本人（或联合作者）编写，代码所有权归本人（或联合作者）所有。
- [x] 此 PR 更新日志已提供（或无须提供）。
- [x] Readme 文档无须补充（或已补充）。
