### PR TITLE
更换GsonBuild被废弃语句、重写“已安装”标识逻辑

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -4,6 +4,6 @@
     <option name="jvmTarget" value="21" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0-RC3" />
+    <option name="version" value="2.0.0" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = gitCommitCount
-        versionName = "1.2.8-$gitCommitHash"
+        versionName = "1.2.9-$gitCommitHash"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/data/QQVersionBean.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/data/QQVersionBean.kt
@@ -28,5 +28,6 @@ data class QQVersionBean(
 
     var jsonString: String,
     var displayType: Int = 0, // 0为收起
+    var displayInstall: Boolean = false, // false 为不展示
     var isShowProgressSize: Boolean = false
 )

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -232,7 +232,7 @@ class MainActivity : AppCompatActivity() {
                                 "提供 Android QQ 版本列表的查看和对 Android QQ 下载链接的枚举法猜测。\n\n" +
                                 "版本：${BuildConfig.VERSION_NAME}(${BuildConfig.VERSION_CODE})\n" +
                                 "作者：快乐小牛、有鲫雪狐\n" +
-                                "贡献者：Col_or、bggRGjQaUbCoE\n" +
+                                "贡献者：Col_or、bggRGjQaUbCoE、GMerge\n" +
                                 "开源地址：GitHub\n" +
                                 "开源协议：AGPL v3\n" +
                                 "获取更新：GitHub Releases、Obtainium、九七通知中心\n\n" +
@@ -260,6 +260,12 @@ class MainActivity : AppCompatActivity() {
                         URLSpan("https://github.com/bggRGjQaUbCoE"),
                         message.indexOf("bggRGjQaUbCoE"),
                         message.indexOf("bggRGjQaUbCoE") + "bggRGjQaUbCoE".length,
+                        SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    message.setSpan(
+                        URLSpan("https://github.com/egmsia01"),
+                        message.indexOf("GMerge"),
+                        message.indexOf("GMerge") + "GMerge".length,
                         SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE
                     )
                     message.setSpan(
@@ -632,7 +638,10 @@ class MainActivity : AppCompatActivity() {
                 val mode = dialogGuessBinding.spinnerVersion.text.toString()
                 var versionSmall = 0
                 if (mode == "测试版" || mode == "空格版") {
-                    versionSmall =
+                    if (dialogGuessBinding.etVersionSmall.editText?.text.isNullOrEmpty()) throw Exception(
+                        "测试版猜版（含空格版）需要填写小版本号，否则无法猜测测试版。"
+                    )
+                    else versionSmall =
                         dialogGuessBinding.etVersionSmall.editText?.text.toString().toInt()
                 }
                 if (versionSmall % 5 != 0 && !DataStoreUtil.getBoolean(
@@ -649,7 +658,7 @@ class MainActivity : AppCompatActivity() {
                 guessUrl(versionBig, versionSmall, mode)
 
             } catch (e: Exception) {
-                e.printStackTrace()
+                if (e.message != "测试版猜版（含空格版）需要填写小版本号，否则无法猜测测试版。" && e.message != "小版本号需填 5 的倍数。如有需求，请前往设置解除此限制。") e.printStackTrace()
                 dialogError(e)
             }
         }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -674,7 +674,7 @@ class MainActivity : AppCompatActivity() {
                 val QQPackageInfo = packageManager.getPackageInfo("com.tencent.mobileqq", 0)
                 val QQVersionInstall = QQPackageInfo.versionName
                 if (QQVersionInstall != DataStoreUtil.getString("QQVersionInstall", "")) {
-                    DataStoreUtil.putStringAsync("QQVersionInstall", QQVersionInstall)
+                    DataStoreUtil.putString("QQVersionInstall", QQVersionInstall)
                 }
             } catch (e: Exception) {
                 DataStoreUtil.putStringAsync("QQVersionInstall", "")

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -89,7 +89,7 @@ class MainActivity : AppCompatActivity() {
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+        if (SDK_INT <= Build.VERSION_CODES.Q) {
             ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsetsCompat.Type.navigationBars())
                 view.setPadding(insets.left, 0, insets.right, 0)
@@ -107,7 +107,7 @@ class MainActivity : AppCompatActivity() {
             window.isStatusBarContrastEnforced = false
         }
 
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+        if (SDK_INT <= Build.VERSION_CODES.Q) {
             window.statusBarColor = Color.TRANSPARENT
             window.navigationBarColor = Color.TRANSPARENT
         }
@@ -670,9 +670,12 @@ class MainActivity : AppCompatActivity() {
         binding.progressLine.show()
         CoroutineScope(Dispatchers.IO).launch {
             try {
+                // 识别本机 Android QQ 版本并放进持久化存储
                 val QQPackageInfo = packageManager.getPackageInfo("com.tencent.mobileqq", 0)
                 val QQVersionInstall = QQPackageInfo.versionName
-                DataStoreUtil.putStringAsync("QQVersionInstall", QQVersionInstall)
+                if (QQVersionInstall != DataStoreUtil.getString("QQVersionInstall", "")) {
+                    DataStoreUtil.putStringAsync("QQVersionInstall", QQVersionInstall)
+                }
             } catch (e: Exception) {
                 DataStoreUtil.putStringAsync("QQVersionInstall", "")
             } finally {
@@ -695,6 +698,11 @@ class MainActivity : AppCompatActivity() {
                             Gson().fromJson(json, QQVersionBean::class.java).apply {
                                 jsonString = json
                                 this.isShowProgressSize = isShowProgressSize
+                                // 标记本机 Android QQ 版本
+                                this.displayInstall = (DataStoreUtil.getString(
+                                    "QQVersionInstall",
+                                    ""
+                                ) == this.versionNumber)
                             }
                         }
                         if (DataStoreUtil.getBoolean(

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -30,6 +30,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import coil.transform.RoundedCornersTransformation
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.progressindicator.LinearProgressIndicator
@@ -134,7 +135,8 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
                     }
                     linearImages.addView(iv)
                     iv.load(it) {
-                        crossfade(200)
+                        crossfade(true)
+                        transformations(RoundedCornersTransformation(2.dp.toFloat()))
                     }
                 }
                 tvOldVersion.text = bean.versionNumber

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/VersionAdapter.kt
@@ -123,10 +123,7 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
                 tvVersion.text = bean.versionNumber
                 tvSize.text = bean.size + " MB"
                 bindProgress(listProgressLine, null, tvPerSizeText, tvPerSizeCard, tvSizeCard, bean)
-                if (DataStoreUtil.getString("QQVersionInstall", "") == bean.versionNumber) {
-                    tvInstallCard.isVisible = true
-                    tvInstall.text = "已安装"
-                } else tvInstallCard.isVisible = false
+                bindDisplayInstall(tvInstall, tvInstallCard, bean)
             }
         } else if (holder is ViewHolderDetail) {
             holder.binding.apply {
@@ -149,10 +146,7 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
 
                 tvTitle.isVisible = tvTitle.text != ""
 
-                if (DataStoreUtil.getString("QQVersionInstall", "") == bean.versionNumber) {
-                    tvOldInstallCard.isVisible = true
-                    tvOldInstall.text = "已安装"
-                } else tvOldInstallCard.isVisible = false
+                bindDisplayInstall(tvOldInstall, tvOldInstallCard, bean)
 
                 bindProgress(
                     listDetailProgressLine,
@@ -202,7 +196,20 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
 
             }
         }
+    }
 
+    @SuppressLint("SetTextI18n")
+    private fun bindDisplayInstall(
+        tvInstall: TextView,
+        tvInstallCard: MaterialCardView,
+        bean: QQVersionBean
+    ) {
+        if (bean.displayInstall) {
+            tvInstallCard.isVisible = true
+            tvInstall.text = "已安装"
+        } else {
+            tvInstallCard.isVisible = false
+        }
     }
 
     private fun showDialog(context: Context, s: String) {
@@ -253,6 +260,22 @@ class VersionAdapter : ListAdapter<QQVersionBean, RecyclerView.ViewHolder>(Versi
                         )
                     }
                 }
+
+                "displayInstall" -> {
+                    if (holder is ViewHolder) {
+                        bindDisplayInstall(
+                            holder.binding.tvInstall,
+                            holder.binding.tvInstallCard,
+                            bean
+                        )
+                    } else if (holder is ViewHolderDetail) {
+                        bindDisplayInstall(
+                            holder.binding.tvOldInstall,
+                            holder.binding.tvOldInstallCard,
+                            bean
+                        )
+                    }
+                }
             }
         }
     }
@@ -273,6 +296,7 @@ class VersionDiffCallback : DiffUtil.ItemCallback<QQVersionBean>() {
     ): Boolean {
         return oldItem.displayType == newItem.displayType
                 && oldItem.isShowProgressSize == newItem.isShowProgressSize
+                && oldItem.displayInstall == newItem.displayInstall
     }
 
     override fun getChangePayload(
@@ -281,6 +305,7 @@ class VersionDiffCallback : DiffUtil.ItemCallback<QQVersionBean>() {
     ): Any? {
         return if (oldItem.displayType != newItem.displayType) "displayType"
         else if (oldItem.isShowProgressSize != newItem.isShowProgressSize) "isShowProgressSize"
+        else if (oldItem.displayInstall != newItem.displayInstall) "displayInstall"
         else null
     }
 

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
@@ -32,24 +32,32 @@ object InfoUtil {
         }
     }
 
-    fun Activity.dialogError(e: Exception) {
+    fun Activity.dialogError(e: Exception, isCustomMessage: Boolean = false) {
         runOnUiThread {
+            val message = if (isCustomMessage) e.message else buildString {
+                appendLine("如需反馈，请前往 GitHub 仓库报告 Issue(s) 并随附以下信息：\n")
+                appendLine(e.stackTraceToString())
+            }
+
             MaterialAlertDialogBuilder(this)
                 .setTitle("程序出错")
                 .setIcon(R.drawable.alert_line)
                 .setPositiveButton("确定", null)
                 .setCancelable(false)
                 .setNeutralButton("复制", null)
+                .setMessage(message)
                 .create()
                 .apply {
-                    if (e.message != "测试版猜版（含空格版）需要填写小版本号，否则无法猜测测试版。" && e.message != "小版本号需填 5 的倍数。如有需求，请前往设置解除此限制。") setMessage("如需反馈，请前往 GitHub 仓库报告 Issue(s) 并随附以下信息：\n\n" + e.stackTraceToString())
-                    else setMessage(e.message)
-                    show()
-                    getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
-                        copyText("" + e.stackTraceToString())
+                    setOnShowListener {
+                        getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
+                            if (isCustomMessage) e.message?.let { it1 -> copyText(it1) }
+                            else copyText(e.stackTraceToString())
+                        }
                     }
+                    show()
                 }
         }
     }
+
 
 }

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/InfoUtil.kt
@@ -37,12 +37,13 @@ object InfoUtil {
             MaterialAlertDialogBuilder(this)
                 .setTitle("程序出错")
                 .setIcon(R.drawable.alert_line)
-                .setMessage("如需反馈，请前往 GitHub 仓库报告 Issue(s) 并随附以下信息：\n\n" + e.stackTraceToString())
                 .setPositiveButton("确定", null)
                 .setCancelable(false)
                 .setNeutralButton("复制", null)
                 .create()
                 .apply {
+                    if (e.message != "测试版猜版（含空格版）需要填写小版本号，否则无法猜测测试版。" && e.message != "小版本号需填 5 的倍数。如有需求，请前往设置解除此限制。") setMessage("如需反馈，请前往 GitHub 仓库报告 Issue(s) 并随附以下信息：\n\n" + e.stackTraceToString())
+                    else setMessage(e.message)
                     show()
                     getButton(AlertDialog.BUTTON_NEUTRAL).setOnClickListener {
                         copyText("" + e.stackTraceToString())

--- a/app/src/main/java/com/xiaoniu/qqversionlist/util/StringUtil.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/util/StringUtil.kt
@@ -20,17 +20,17 @@ package com.xiaoniu.qqversionlist.util
 
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParser
+import com.google.gson.Strictness
 
 object StringUtil {
+    private val gsonBuilder = GsonBuilder().setStrictness(Strictness.LENIENT).setPrettyPrinting()
     fun String.toPrettyFormat(): String {
         return try {
             val jsonObject = JsonParser.parseString(this).asJsonObject
-            val gson = GsonBuilder().setLenient().setPrettyPrinting().create()
-            gson.toJson(jsonObject)
+            gsonBuilder.create().toJson(jsonObject)
         } catch (e: Exception) {
             e.printStackTrace()
             this
         }
     }
-
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.4.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.0.0-RC3" apply false
+    id("com.android.application") version "8.4.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-kotlin.experimental.tryK2=true


### PR DESCRIPTION
## 这个 PR 解决了什么问题？

> 请补充以下信息

### 需求背景

1. QVT 1.2.8 版本中，如果用户打开 QVT 后更新 Android QQ 版本再返回 QVT，点击刷新并不会更新“已安装”标识
2. Gson 2.11.0 废弃了 `setLenient()` 语句
3. Kotlin 2.0.0 RC 3 和 Kotlin 2.0.0 Release 默认启用 K2 编译器
4. QVT 里确实还没有对一些规则限制（比如小版本号不能为 5 的倍数这些）做梳理拦截和自定义提示，所以触发这些限制后都会弹出很长很长的程序出错堆栈提示框。

### 更新日志

#### 修复

- 修复：打开 QVT 后更新 Android QQ 版本再返回 QVT，点击刷新并不会更新“已安装”标识的 Bug

#### 优化

- 优化：小版本号 5 的倍数限制和小版本号判空限制的报错提示更可读
- 优化：版本列表展开后的图片视图添加 Coil 自带圆角效果

#### 其它更改

- 使用 `setStrictness(Strictness.LENIENT)` 替代 Gson 2.11.0 废弃的 `setLenient()`
- 去掉 K2 编译器的显式声明
- 关于界面贡献者新增 [GMerge](https://github.com/egmsia01)

#### 上游更改

- 更新：Kotlin 更新至 2.0.0
- 更新：Android Gradle Plugin 更新至 8.4.1

## 自检清单

> 请检查下列所有选项并打勾

- [x] 此 PR 已实现我的所有预期更改，可以被合并。
- [x] 我确认此 PR 全部代码仅由本人（或联合作者）编写，代码所有权归本人（或联合作者）所有。
- [x] 此 PR 更新日志已提供（或无须提供）。
- [x] Readme 文档无须补充（或已补充）。
