### PR TITLE
修复猜版"测试版"、"空格版"小版本号为空时的NPE问题

### DIFF
--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -636,7 +636,7 @@ class MainActivity : AppCompatActivity() {
                         dialogGuessBinding.etVersionSmall.editText?.text?.toString()?.toIntOrNull() ?: -1
                 }
                 if (versionSmall == -1) {
-                    showToast("小版本号不能为空。")
+                    showToast("小版本号不能为空")
                     return@setOnClickListener
                 }
                 if (versionSmall % 5 != 0 && !DataStoreUtil.getBoolean(

--- a/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
+++ b/app/src/main/java/com/xiaoniu/qqversionlist/ui/MainActivity.kt
@@ -633,7 +633,11 @@ class MainActivity : AppCompatActivity() {
                 var versionSmall = 0
                 if (mode == "测试版" || mode == "空格版") {
                     versionSmall =
-                        dialogGuessBinding.etVersionSmall.editText?.text.toString().toInt()
+                        dialogGuessBinding.etVersionSmall.editText?.text?.toString()?.toIntOrNull() ?: -1
+                }
+                if (versionSmall == -1) {
+                    showToast("小版本号不能为空。")
+                    return@setOnClickListener
                 }
                 if (versionSmall % 5 != 0 && !DataStoreUtil.getBoolean(
                         "guessNot5", false


### PR DESCRIPTION
## 这个 PR 解决了什么问题？

> 请补充以下信息

### 需求背景

猜版中"测试版"和"空格版"需要输入小版本号，在不输入小版本号的情况下直接点"开始"按钮会导致空指针问题。

### 更新日志

#### 修复

- 修复猜版"测试版"和"空格版"小版本号为空时的空指针问题

## 自检清单

> 请检查下列所有选项并打勾

- [x] 此 PR 已实现我的所有预期更改，可以被合并。
- [x] 我确认此 PR 全部代码仅由本人（或联合作者）编写，代码所有权归本人（或联合作者）所有。
- [x] 此 PR 更新日志已提供（或无须提供）。
- [x] Readme 文档无须补充（或已补充）。
